### PR TITLE
Add configuration round-trip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ to the config repository manually.
 
 Example of the `template.yaml` file with decsription can be found in [tests/example_template.yaml](tests/example_template.yaml)
 
+### roundtrip
+```
+ipamanager roundtrip config
+```
+The `roundtrip` command can be used to load entities from config files
+(like the `check` command, but without integrity checking), then store
+them right back to the configuration files.
+
+This can be useful when your config is technically correct, but there are
+style issues in it (e.g., the `memberOf` lists values are unsorted).
+Round-trip will fix these issues. Alternatively, a `pull` operation would
+fix such issues in the config of entities changed on the FreeIPA server as well,
+but such a commit would contain both server-side changes and style fixes;
+this could lead to a confusing diff, which may be undesirable.
+
+### Dry run
 The *dry run* mode can be choosen with `-d` or `--dry-run` flag.
 
 ## Configuration
@@ -404,11 +420,6 @@ could be bundled with the tool directly to facilitate easier usage.
 Since *freeipa-manager* is a tool for Linux environment, distributing a manual entry
 with it would be reasonable, since it's the standard for Linux tools.
 Similarly, `Tab` key auto-completion of commands is a standard and would be useful.
-### Configuration round-trip
-Support loading configuration from files, running integrity check and dumping it back
-into config files. This would be useful for cases when config files are *technically*
-correct but there is a "style" issue to fix in them (e.g., `memberOf` list entries
-are not sorted).
 ### Support for pure LDAP
 The tool could possibly interface LDAP directly instead of the higher-level FreeIPA
 API. This would enable a wider range of applications.

--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.3
+Version:        1.4
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
@@ -44,6 +44,8 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-pull-request
 
 %changelog
+* Fri Apr 26 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.4-1
+- Support round-trip (load & save) of configuration
 * Wed Mar 27 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.3-1
 - Support logging to syslog as well
 * Thu Mar 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.2-1

--- a/ipamanager/config_loader.py
+++ b/ipamanager/config_loader.py
@@ -24,14 +24,16 @@ class ConfigLoader(FreeIPAManagerCore):
     :attr dict entities: storage of loaded entities, which are organized
                          in nested dicts under entity type & entity name keys
     """
-    def __init__(self, basepath, settings):
+    def __init__(self, basepath, settings, ignore=True):
         """
         :param str basepath: path to the cloned config repository
         :param dict settings: parsed contents of the settings file
+        :param bool ignore: whether ignoring settings are taken into account
         """
         super(ConfigLoader, self).__init__()
         self.basepath = basepath
         self.ignored = settings.get('ignore', dict())
+        self.ignore = ignore
         self.entities = dict()
 
     def load(self):
@@ -84,7 +86,7 @@ class ConfigLoader(FreeIPAManagerCore):
         fname = os.path.relpath(path, self.basepath)
         for name, attrs in data.iteritems():
             self.lg.debug('Creating entity %s', name)
-            if check_ignored(entity_class, name, self.ignored):
+            if self.ignore and check_ignored(entity_class, name, self.ignored):
                 self.lg.info('Not creating ignored %s %s from %s',
                              entity_class.entity_name, name, fname)
                 continue

--- a/ipamanager/entities.py
+++ b/ipamanager/entities.py
@@ -149,6 +149,18 @@ class FreeIPAEntity(FreeIPAManagerCore):
         """
         self.data_repo.update(additional or {})
 
+    def normalize(self):
+        """
+        Re-structure entity's data in such a way that it can be stored
+        into the configuration file in a normalized format. This is used
+        when round-trip loading and saving a configuration.
+        """
+        memberof = self.data_repo.pop('memberOf', None)
+        if memberof:
+            for target_type, target_list in memberof.iteritems():
+                memberof[target_type] = sorted(target_list)
+            self.data_repo['memberOf'] = memberof
+
     def write_to_file(self):
         if not self.path:
             raise ManagerError(

--- a/ipamanager/utils.py
+++ b/ipamanager/utils.py
@@ -127,6 +127,12 @@ def parse_args():
         '-d', '--dry-run', action='store_true', help='Dry-run mode')
     template.set_defaults(action='template')
 
+    roundtrip = actions.add_parser('roundtrip', parents=[common])
+    roundtrip.add_argument(
+        '-I', '--no-ignored', action='store_true',
+        help='Load all entities (including ignored ones)')
+    roundtrip.set_defaults(action='roundtrip')
+
     args = parser.parse_args()
     # type & action cannot be combined in arg constructor, so parse -v here
     args.loglevel = _type_verbosity(args.loglevel)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -413,6 +413,23 @@ class TestFreeIPAUser(object):
                 'role': ['role-one-users', 'role-two']},
             'sn': ('Name',)}
 
+    def test_normalize(self):
+        data = {
+            'firstName': 'Some',
+            'lastName': 'Name',
+            'manager': 'sample.manager',
+            'memberOf': {
+                        'group': ['group-two-users', 'group-one'],
+                        'role': ['role-one-users', 'role-two']
+            }
+        }
+        user = tool.FreeIPAUser('test.user', data, 'path')
+        user.normalize()
+        assert user.data_repo['memberOf'] == {
+            'group': ['group-one', 'group-two-users'],
+            'role': ['role-one-users', 'role-two']
+        }
+
     def test_create_user_extrakey(self):
         with pytest.raises(tool.ConfigError) as exc:
             tool.FreeIPAUser('test.user', {'extrakey': 'bad'}, 'path')


### PR DESCRIPTION
Support loading entities from config
files & then saving them right back.

This can be useful to get the config
into a 'normalized' state (e.g., get
rid of empty 'metaparams' key & sort
the items in the memberOf key values.