### PR TITLE
Prepare infrastructure for alerting plugins

### DIFF
--- a/ipamanager/freeipa_manager.py
+++ b/ipamanager/freeipa_manager.py
@@ -30,7 +30,8 @@ class FreeIPAManager(FreeIPAManagerCore):
     def __init__(self):
         super(FreeIPAManager, self).__init__()
         self.args = utils.parse_args()
-        utils.init_logging(self.args.loglevel)
+        self.alerting_handler = utils.AlertingLogHandler()
+        utils.init_logging(self.args.loglevel, self.alerting_handler)
         self._load_settings()
 
     def run(self):

--- a/ipamanager/utils.py
+++ b/ipamanager/utils.py
@@ -33,7 +33,7 @@ ENTITY_CLASSES = [
 ]
 
 
-def init_logging(loglevel):
+def init_logging(loglevel, *extra_handlers):
     lg = logging.getLogger()  # add handlers to all loggers
     lg.setLevel(logging.DEBUG)  # higher levels per handler below
 
@@ -46,6 +46,13 @@ def init_logging(loglevel):
     handler_stderr.setFormatter(logging.Formatter(fmt=fmt))
     handler_stderr.setLevel(loglevel)
     lg.addHandler(handler_stderr)
+    lg.debug('Stderr handler added to root logger')
+
+    # add extra handlers (e.g., alerting handler) before syslog
+    # (so that possible syslog error is propagated to alerting)
+    for handler in extra_handlers:
+        lg.addHandler(handler)
+        lg.debug('Handler %s added to root logger', handler)
 
     # syslog output handler
     try:

--- a/ipamanager/utils.py
+++ b/ipamanager/utils.py
@@ -63,8 +63,29 @@ def init_logging(loglevel, *extra_handlers):
             logging.Formatter(fmt='ipamanager: %(message)s'))
         handler_syslog.setLevel(logging.INFO)
         lg.addHandler(handler_syslog)
+        lg.debug('Syslog handler added to root logger')
     except socket.error as err:
         lg.error('Syslog connection failed: %s', err)
+
+
+class AlertingLogHandler(logging.Handler):
+    """
+    A handler to capture messages to be forwarded to an alerting system.
+    This should only capture non-OK messages (WARNING and above).
+    """
+    def __init__(self):
+        """
+        :param AlertingCollector collector: object to hold messages & max level
+        """
+        super(AlertingLogHandler, self).__init__()
+        self.setLevel(logging.WARNING)
+        self.setFormatter(logging.Formatter(fmt='%(levelname)s: %(message)s'))
+        self.messages = []
+        self.max_level = logging.NOTSET
+
+    def emit(self, record):
+        self.messages.append(self.format(record))
+        self.max_level = max(self.max_level, record.levelno)
 
 
 def init_api_connection(loglevel):

--- a/tests/test_ipa_connector.py
+++ b/tests/test_ipa_connector.py
@@ -34,7 +34,7 @@ class TestIpaConnectorBase(object):
 
     def _create_uploader(self, **args):
         with open(SETTINGS) as settings_file:
-            self.settings = yaml.load(settings_file)
+            self.settings = yaml.safe_load(settings_file)
 
         self.uploader = tool.IpaUploader(
             settings=self.settings,
@@ -201,7 +201,7 @@ class TestIpaUploader(TestIpaConnectorBase):
             'givenname': u'Test', 'sn': u'User', 'uid': u'test.user'}
 
     def test_parse_entity_diff_extended_latin(self):
-        name = yaml.load(u'Tešt')
+        name = yaml.safe_load(u'Tešt')
         entity = entities.FreeIPAUser(
             'test.user', {'firstName': name, 'lastName': 'User'}, 'path')
         self.uploader.ipa_entities = {
@@ -253,7 +253,7 @@ class TestIpaUploader(TestIpaConnectorBase):
             'mail': (), 'sn': u'User', 'uid': u'test.user'}
 
     def test_parse_entity_diff_mod_extended_latin_same(self):
-        name = yaml.load(u'Tešt')
+        name = yaml.safe_load(u'Tešt')
         entity = entities.FreeIPAUser(
             'test.user',
             {'firstName': name, 'lastName': 'User',
@@ -276,7 +276,7 @@ class TestIpaUploader(TestIpaConnectorBase):
         assert len(self.uploader.commands) == 0
 
     def test_parse_entity_diff_mod_extended_latin(self):
-        name = yaml.load(u'Tešt')
+        name = yaml.safe_load(u'Tešt')
         entity = entities.FreeIPAUser(
             'test.user',
             {'firstName': name, 'lastName': 'User',
@@ -836,7 +836,7 @@ class TestIpaUploader(TestIpaConnectorBase):
 class TestIpaDownloader(TestIpaConnectorBase):
     def setup_method(self, method):
         with open(SETTINGS) as settings_file:
-            self.settings = yaml.load(settings_file)
+            self.settings = yaml.safe_load(settings_file)
         self._create_downloader()
         if method.func_name.startswith('test_dump_membership'):
             self.downloader.ipa_entities = {

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -231,7 +231,9 @@ class TestTemplate(object):
         self.template_tool._dump_entities()
         assert os.listdir(os.path.join(tmpdir.strpath, 'hostgroups')) == ['dummy_666.yaml']
         with open(os.path.join(tmpdir.strpath, 'hostgroups/dummy_666.yaml'), 'r') as f:
-            assert yaml.load(f) == {'dummy-666': {'description': 'all description', 'metaparams': {'meta': 'param'}}}
+            assert yaml.safe_load(f) == {
+                'dummy-666': {'description': 'all description',
+                              'metaparams': {'meta': 'param'}}}
 
     def test_load_data(self):
         loaded = self.loader.load_config()


### PR DESCRIPTION
Prepare the tool to support alerting plugins:
* support adding extra handlers to the logger;
* implement a handler to collect alerting messages.
Other changes:
* fix warnings about `yaml.load` being unsafe by using `yaml.safe_load` in tests.