### PR TITLE
Support including in settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,32 @@ This would instantiate the plugins `alerting.test_monitoring.TestMonitoringPlugi
 and `alerting.other.testOtherAlertingPlugin`. The `config` dictionary value is
 passed to the plugin instance without modification.
 
+#### include
+A settings file can be included inside another one; this permits us, for example,
+to define common settings for several use cases, and then include this common config
+file to other configs that will extend it for specific use cases:
+```yaml
+# common config
+nesting-limit: 4
+ignore:
+  user: [test]
+---
+# specific config:
+include:
+  - "common.yaml"
+alerting:
+  test-monitoring:
+    module: test_monitoring
+    class: TestMonitoringPlugin
+```
+
+#### merge\_include
+The `merge\_include` parameter defines whether matching dict-type keys in included
+configs should be merged with the value in the current file, rather then overwritten:
+```yaml
+include: ["common.yaml"]
+merge_include: true
+```
 
 ## Further development
 Several new features of *freeipa-manager* are planned for the future, such as:

--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.5
+Version:        1.6
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
@@ -45,6 +45,8 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-pull-request
 
 %changelog
+* Tue May 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.5-1
+- Support includes in settings file
 * Tue May 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.5-1
 - Implement NSCA alerting plugin
 * Fri Apr 26 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.4-1

--- a/ipamanager/freeipa_manager.py
+++ b/ipamanager/freeipa_manager.py
@@ -12,8 +12,6 @@ Main entry point of the tooling, responsible for delegating the tasks.
 import importlib
 import logging
 import sys
-import voluptuous
-import yaml
 
 import utils
 from core import FreeIPAManagerCore
@@ -21,7 +19,6 @@ from config_loader import ConfigLoader
 from difference import FreeIPADifference
 from errors import ManagerError
 from integrity_checker import IntegrityChecker
-from schemas import schema_settings
 from template import FreeIPATemplate, ConfigTemplateLoader
 
 
@@ -191,14 +188,9 @@ class FreeIPAManager(FreeIPAManagerCore):
             raise ManagerError('No settings file configured')
         self.lg.debug('Loading settings file from %s', self.args.settings)
         try:
-            with open(self.args.settings) as src:
-                raw = src.read()
-                utils.run_yamllint_check(raw)
-                self.settings = yaml.safe_load(raw)
-                # run validation of parsed YAML against schema
-                voluptuous.Schema(schema_settings)(self.settings)
+            self.settings = utils.load_settings(self.args.settings)
         except Exception as e:
-            raise ManagerError('Error reading settings file: %s' % e)
+            raise ManagerError('Error loading settings: %s' % e)
         self.lg.debug('Settings parsed: %s', self.settings)
 
 

--- a/ipamanager/schemas.py
+++ b/ipamanager/schemas.py
@@ -17,6 +17,8 @@ _meta = {str: {str: str}}
 
 
 schema_settings = {
+    'include': list,
+    'merge_include': bool,
     'alerting': {
         str: {
             Required('module'): str,

--- a/ipamanager/utils.py
+++ b/ipamanager/utils.py
@@ -11,15 +11,18 @@ Various utility functions for better code readability & organization.
 import argparse
 import logging
 import logging.handlers
+import os
 import re
 import socket
 import sys
+import voluptuous
 import yaml
 from yamllint.config import YamlLintConfig
 from yamllint.linter import run as yamllint_check
 
 import entities
 from errors import ConfigError
+from schemas import schema_settings
 
 
 # supported FreeIPA entity types
@@ -160,6 +163,44 @@ def run_yamllint_check(data):
     lint_errs = list(yamllint_check(data, YamlLintConfig(yaml.dump(rules))))
     if lint_errs:
         raise ConfigError('yamllint errors: %s' % lint_errs)
+
+
+def _merge_include(target, source):
+    for key, value in source.iteritems():
+        if isinstance(value, dict) and key in target:
+            target[key].update(value)
+        else:
+            target[key] = value
+
+
+def load_settings(path):
+    """
+    Load the tool settings from the given file.
+    If there is an include parameter in the settings file,
+    the listed files are included in the config.
+    :param str path: path to the settings file
+    :returns: loaded settings file
+    :rtype: dict
+    """
+    result = {}
+    with open(path) as src:
+        raw = src.read()
+        run_yamllint_check(raw)
+        settings = yaml.safe_load(raw)
+    # run validation of parsed YAML against schema
+    voluptuous.Schema(schema_settings)(settings)
+    subconfigs = []
+    for included in settings.pop('include', []):
+        subconf = load_settings(os.path.join(os.path.dirname(path), included))
+        subconfigs.append(subconf)
+    subconfigs.append(settings)
+    merge_include = settings.pop('merge_include', False)
+    for config in subconfigs:
+        if merge_include:
+            _merge_include(result, config)
+        else:
+            result.update(config)
+    return result
 
 
 def check_ignored(entity_class, name, ignored):

--- a/tests/freeipa-manager-config/settings_include.yaml
+++ b/tests/freeipa-manager-config/settings_include.yaml
@@ -1,0 +1,13 @@
+---
+include:
+  - "settings.yaml"
+
+alerting:
+  plugin1:
+    module: abc
+    class: def
+    config:
+      key1: value1
+  plugin2:
+    module: abc
+    class: def2

--- a/tests/freeipa-manager-config/settings_merge.yaml
+++ b/tests/freeipa-manager-config/settings_merge.yaml
@@ -1,0 +1,16 @@
+---
+include: ['settings.yaml']
+merge_include: true
+
+alerting:
+  plugin1:
+    module: abc
+    class: def
+    config:
+      key1: value1
+  plugin2:
+    module: abc
+    class: def2
+ignore:
+  group: [group2, group3]
+  service: [serviceX]


### PR DESCRIPTION
Add support for the include key in
the settings file. This will allow
reuse of parts of the same config.

This way, it is possible to define
common alerting settings in 1 file
while only action-specific configs
need to be separate in other files.

The merge_include parameter allows
toggling between overwrite & merge
of matching key in included config.