### PR TITLE
Do not re-add logging handler multiple times

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-manager
 Version:        1.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
 License:        BSD License 2.0
@@ -45,7 +45,9 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-pull-request
 
 %changelog
-* Tue May 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.5-1
+* Thu May 23 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.6-2
+- Do not re-add logging handlers if already setup
+* Tue May 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.6-1
 - Support includes in settings file
 * Tue May 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.5-1
 - Implement NSCA alerting plugin


### PR DESCRIPTION
Check if a handler with given properties was
already added to the root logger, and if so,
do not try to re-add it anymore, in order to
avoid duplicit log messages. This didn't use
to matter that much previously as the logger
handlers were cleaned on every tool restart,
but we have new use cases turning up now and
they will include importing tool's component
to another tool, which could re-init logging
and re-add handlers, causing duplicate logs.