### PR TITLE
Implement config query tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ fix such issues in the config of entities changed on the FreeIPA server as well,
 but such a commit would contain both server-side changes and style fixes;
 this could lead to a confusing diff, which may be undesirable.
 
+### Tools
+There is a separate `ipamanager.tools` sub-package, providing tools that are not
+required for the core tool's functionality but can be used to enhance workflows.
+
+#### github-forwarder
+Create a GitHub pull request from the given branch of the config repo.
+Can be useful with the `pull` action.
+```
+ipamanager-pull-request -b new-changes -B master -o my-organization -r config-repo -u github-user -c  # commit changes
+ipamanager-pull-request -b new-changes -B master -o my-organization -r config-repo -u github-user -p  # commit changes & create PR
+```
+
+#### query-tool
+Query the config repo for various meta-values or relationships between entities.
+
+For example, to find if a group called `group1` is a member of the group `group2`
+(including indirect membership), run:
+```
+ipamanager-query member config-repo -m group:group1 -e group:group2
+```
+
 ### Dry run
 The *dry run* mode can be choosen with `-d` or `--dry-run` flag.
 

--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-manager
-Version:        1.6
-Release:        2%{?dist}
+Version:        1.7
+Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
 License:        BSD License 2.0
@@ -45,6 +45,8 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-pull-request
 
 %changelog
+* Tue May 28 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.7-1
+- Add a query tool into ipamanager.tools
 * Thu May 23 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.6-2
 - Do not re-add logging handlers if already setup
 * Tue May 14 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.6-1

--- a/ipamanager/tools/query_tool.py
+++ b/ipamanager/tools/query_tool.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2017-2019, GoodData Corporation. All rights reserved.
+"""
+FreeIPA Manager - query tool
+
+A tool for querying entities for various purposes, like:
+- checking if user is a member of a (nested) group,
+- security label checking,
+- etc.
+"""
+
+import argparse
+import collections
+import logging
+import os
+
+from ipamanager.config_loader import ConfigLoader
+from ipamanager.errors import ManagerError
+from ipamanager.integrity_checker import IntegrityChecker
+from ipamanager.utils import _args_common, find_entity
+from ipamanager.utils import load_settings, _type_verbosity
+from ipamanager.tools.core import FreeIPAManagerToolCore
+
+
+class QueryTool(FreeIPAManagerToolCore):
+    """
+    A query tool for inquiry operations over entities,
+    like nested membership or security label checking.
+    """
+    def __init__(self, config, settings=None, loglevel=logging.INFO):
+        """
+        Initialize the query tool class instance.
+        :param str config: path to a freeipa-manager-config folder
+        :param str settings: path to a settings file
+        :param int loglevel: logging level to use
+        """
+        self.config = config
+        if not settings:
+            settings = os.path.join(config, 'settings_common.yaml')
+        self.settings = load_settings(settings)
+        super(QueryTool, self).__init__(loglevel)
+        self.graph = {}
+        self.ancestors = {}
+        self.paths = {}
+
+    def load(self):
+        """
+        Load and verify entity config to perform queries on.
+        Uses the ConfigLoader and IntegrityChecker components.
+        """
+        self.lg.info('Running pre-query config load & checks')
+        self.entities = ConfigLoader(self.config, self.settings).load()
+        self.checker = IntegrityChecker(self.entities, self.settings)
+        self.checker.check()
+        self.lg.info('Pre-query config load & checks finished')
+
+    def run(self, action, *args):
+        """
+        Run a query action based on arguments.
+        :param str action: action to perform (membership/security check)
+        :param [obj] args: arguments to pass to the action method
+        """
+        if action == 'member':
+            self._query_membership(*args)
+
+    def _resolve_entities(self, entity_list):
+        """
+        Find entities from config based on their types and names.
+        :param [str] entity_list: entities in type:name format
+        :returns: list of resolved entities
+        :rtype: [FreeIPAEntity]
+        :raises ManagerError: if an entity is not defined in config
+        """
+        result = []
+        for entity_type, entity_name in entity_list:
+            resolved = find_entity(self.entities, entity_type, entity_name)
+            if not resolved:
+                raise ManagerError('%s %s not found in config'
+                                   % (entity_type, entity_name))
+            result.append(resolved)
+        return result
+
+    def build_graph(self, member):
+        """
+        Find all entities of which `member` is a member.
+        Utilizes the `graph` attribute for caching in case several
+        entities with overlapping membership graphs are evaluated.
+        :param FreeIPAEntity member: entity to search from
+        :returns: list of entities that `member` is a member of
+        :rtype: [FreeIPAEntity]
+        """
+        result = self.graph.get(member, set())
+        if result:
+            self.lg.debug('Membership for %s already calculated', member)
+            return result
+        self.lg.debug('Calculating membership graph for %s', member)
+        memberof = member.data_repo.get('memberOf', {})
+        for entity_type, entity_list in memberof.iteritems():
+            for entity_name in entity_list:
+                entity = find_entity(self.entities, entity_type, entity_name)
+                result.add(entity)
+                if entity in self.ancestors:
+                    self.ancestors[entity].append(member)
+                else:
+                    self.ancestors[entity] = [member]
+                result.update(self.build_graph(entity))
+        self.lg.debug('Found %d entities for %s', len(result), member)
+        self.graph[member] = result
+        return result
+
+    def check_membership(self, member, entity):
+        """
+        Check if `member` is a member of `entity`.
+        :param FreeIPAEntity member: member to evaluate
+        :param FreeIPAEntity entity: entity to evaluate
+        :returns: possible paths from member to entity (empty if not a member)
+        :rtype: [[FreeIPAEntity]]
+        """
+        self.build_graph(member)
+        paths = self._construct_path(entity, member)
+        if paths:
+            self.lg.info(
+                '%s IS a member of %s; possible paths: [%s]',
+                member, entity, '; '.join(' -> '.join(
+                    repr(e) for e in path) for path in paths))
+        else:
+            self.lg.info('%s IS NOT a member of %s', member, entity)
+        return paths
+
+    def _query_membership(self, members, entity_names):
+        """
+        Check membership of each entity from `members`
+        in each entity from `entity_names`.
+        :param [str] members: members to evaluate (type:name format)
+        :param [str] entity_names: entities to evaluate (type:name format)
+        """
+        member_entities = self._resolve_entities(members)
+        entity_list = self._resolve_entities(entity_names)
+        for member in member_entities:
+            for entity in entity_list:
+                self.check_membership(member, entity)
+
+    def _construct_path(self, entity, member):
+        """
+        Find all paths leading from `member` to `entity`.
+        The paths are constructed backwards, based on the `ancestor`
+        mapping constructed in the `build_graph` method.
+        :param FreeIPAEntity entity: entity to search from
+        :param FreeIPAEntity member: member to search towards
+        :returns: list of paths from `member` to `entity` ([] if no path found)
+        :rtype: [[FreeIPAEntity]]
+        """
+        if (member, entity) in self.paths:
+            self.lg.debug('Using cached paths for %s -> %s', member, entity)
+            return self.paths[(member, entity)]
+        paths = []
+        queue = collections.deque([[entity]])
+        while queue:
+            current = queue.popleft()
+            preds = self.ancestors.get(current[0], [])
+            for pred in preds:
+                new_path = [pred] + current
+                if pred == member:
+                    paths.append(new_path)
+                else:
+                    queue.append(new_path)
+        self.paths[(member, entity)] = paths
+        self.lg.debug('Found %d paths %s -> %s', len(paths), member, entity)
+        return paths
+
+
+def _parse_args(args=None):
+    common = _args_common()
+    parser = argparse.ArgumentParser(description='FreeIPA Manager Query')
+    actions = parser.add_subparsers(help='query action to execute')
+
+    member = actions.add_parser('member', parents=[common])
+    member.add_argument(
+        '-m', '--members', nargs='+', type=_entity_type, default=[],
+        required=True, help='members (type:name)')
+    member.add_argument(
+        '-e', '--entities', nargs='+', type=_entity_type, default=[],
+        required=True, help='entities whose members to check (type:name)')
+    member.set_defaults(action='member')
+
+    args = parser.parse_args(args)
+    args.loglevel = _type_verbosity(args.loglevel)
+    return args
+
+
+def _entity_type(value):
+    """
+    Type function used for parsing --members/--entities arguments
+    from colon-separated values into a list of (type, name) 2-tuples.
+    """
+    entity_type, entity_name = value.split(':')
+    return entity_type, entity_name
+
+
+def main():
+    """
+    Main executable function used when run as a command-line script.
+    """
+    args = _parse_args()
+    querytool = QueryTool(args.config, args.settings, args.loglevel)
+    querytool.load()
+    querytool.run(args.action, args.members, args.entities)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 
 with open('requirements.txt') as deps_file:
-    deps = [i.replace('\n', '') for i in deps_file.readlines()]
+    deps = [i.strip() for i in deps_file.readlines()]
 
 
 # Parameters for build
@@ -18,7 +18,8 @@ params = {
     'entry_points': {
         'console_scripts': [
             'ipamanager=ipamanager.freeipa_manager:main',
-            'ipamanager-pull-request=ipamanager.tools.github_forwarder:main']
+            'ipamanager-pull-request=ipamanager.tools.github_forwarder:main',
+            'ipamanager-query=ipamanager.tools.query_tool:main']
     },
     'url': 'https://github.com/gooddata/freeipa-manager',
     'license': 'BSD License 2.0',

--- a/tests/freeipa-manager-config/correct/groups/group_four.yaml
+++ b/tests/freeipa-manager-config/correct/groups/group_four.yaml
@@ -1,0 +1,4 @@
+---
+group-four-users:
+  memberOf:
+    group: [group-three-users]

--- a/tests/freeipa-manager-config/correct/users/firstname_lastname_2.yaml
+++ b/tests/freeipa-manager-config/correct/users/firstname_lastname_2.yaml
@@ -9,4 +9,5 @@ firstname.lastname2:
   title: Sr. SW Enginner
   memberOf:
     group:
+      - group-four-users
       - group-three-users

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -40,7 +40,7 @@ class TestConfigLoader(object):
                 'firstname_lastname', 'firstname_lastname_2', 'test_user']]
         self.expected_groups = [
             CONFIG_CORRECT + '/groups/group_%s.yaml' % group
-            for group in NUMBERS]
+            for group in ['four'] + NUMBERS]
         self.expected_hbac_rules = [
             CONFIG_CORRECT + '/hbacrules/rule_%s.yaml' % rule
             for rule in NUMBERS]
@@ -208,8 +208,9 @@ class TestConfigLoader(object):
         assert set(hbacsvcgroup.keys()) == set([
             'hbacsvcgroup-one', 'hbacsvcgroup-two', 'hbacsvcgroup-three'])
         groups = self.loader.entities['group']
-        assert len(groups) == 2
-        assert set(groups.keys()) == set(['group-two', 'group-three-users'])
+        assert len(groups) == 3
+        assert set(groups.keys()) == set(
+            ['group-two', 'group-three-users', 'group-four-users'])
         service = self.loader.entities['service']
         assert len(service) == 3
         assert set(service.keys()) == set([
@@ -245,7 +246,7 @@ class TestConfigLoader(object):
             ('ConfigLoader', 'INFO',
              ('Not creating ignored group group-one-users '
               'from groups/group_one.yaml')),
-            ('ConfigLoader', 'INFO', 'Parsed 2 groups'))
+            ('ConfigLoader', 'INFO', 'Parsed 3 groups'))
 
     @log_capture('ConfigLoader', level=logging.INFO)
     def test_load_no_apply_ignored(self, captured_log):
@@ -269,9 +270,10 @@ class TestConfigLoader(object):
         assert set(hbacsvcgroup.keys()) == set([
             'hbacsvcgroup-one', 'hbacsvcgroup-two', 'hbacsvcgroup-three'])
         groups = self.loader.entities['group']
-        assert len(groups) == 3
+        assert len(groups) == 4
         assert set(groups.keys()) == set([
-            'group-one-users', 'group-two', 'group-three-users'])
+            'group-one-users', 'group-two',
+            'group-three-users', 'group-four-users'])
         service = self.loader.entities['service']
         assert len(service) == 3
         assert set(service.keys()) == set([
@@ -301,7 +303,7 @@ class TestConfigLoader(object):
             ('ConfigLoader', 'INFO', 'Parsed 3 services'),
             ('ConfigLoader', 'INFO', 'Parsed 3 sudorules'),
             ('ConfigLoader', 'INFO', 'Parsed 3 users'),
-            ('ConfigLoader', 'INFO', 'Parsed 3 groups'))
+            ('ConfigLoader', 'INFO', 'Parsed 4 groups'))
 
     @log_capture('ConfigLoader', level=logging.INFO)
     def test_load_empty(self, captured_log):

--- a/tests/tools/test_query_tool.py
+++ b/tests/tools/test_query_tool.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2017-2019, GoodData Corporation. All rights reserved.
+
+import argparse
+import logging
+import mock
+import os
+import pytest
+import re
+from testfixtures import LogCapture, log_capture
+
+import ipamanager.tools.query_tool as tool
+import ipamanager.entities as entities
+testdir = os.path.dirname(__file__)
+
+modulename = 'ipamanager.tools.query_tool'
+CONFIG_CORRECT = os.path.join(testdir, '../freeipa-manager-config/correct')
+SETTINGS = os.path.join(testdir, '../freeipa-manager-config/settings.yaml')
+
+
+class TestQueryTool(object):
+    def setup_method(self, method):
+        if not method.func_name.startswith('test_init'):
+            self.querytool = tool.QueryTool(CONFIG_CORRECT, SETTINGS)
+            if not re.match(r'^test_(run|load)', method.func_name):
+                with LogCapture():
+                    self.querytool.load()
+            self.querytool.graph = {}
+            self.querytool.ancestors = {}
+            self.querytool.paths = {}
+
+    @mock.patch('%s.load_settings' % modulename)
+    def test_init(self, mock_load_settings):
+        querytool = tool.QueryTool(CONFIG_CORRECT, SETTINGS)
+        mock_load_settings.assert_called_with(SETTINGS)
+        assert querytool.settings == mock_load_settings.return_value
+
+    @mock.patch('%s.load_settings' % modulename)
+    def test_init_no_settings(self, mock_load_settings):
+        tool.QueryTool(CONFIG_CORRECT)
+        mock_load_settings.assert_called_with(os.path.join(
+            testdir, '../freeipa-manager-config/correct/settings_common.yaml'))
+
+    def test_run(self):
+        self.querytool._query_membership = mock.Mock()
+        self.querytool.run('member', [], [])
+        self.querytool._query_membership.assert_called_with([], [])
+
+    @log_capture()
+    @mock.patch('%s.IntegrityChecker' % modulename)
+    @mock.patch('%s.ConfigLoader' % modulename)
+    def test_load(self, mock_loader, mock_checker, log):
+        self.querytool.load()
+        mock_loader.assert_called_with(
+            self.querytool.config, self.querytool.settings)
+        mock_load = mock_loader.return_value.load
+        mock_load.assert_called_with()
+        assert self.querytool.entities == mock_load.return_value
+        mock_checker.assert_called_with(
+            self.querytool.entities, self.querytool.settings)
+        mock_checker.return_value.check.assert_called_with()
+        log.check(
+            ('QueryTool', 'INFO', 'Running pre-query config load & checks'),
+            ('QueryTool', 'INFO', 'Pre-query config load & checks finished'))
+
+    def test_resolve_entities(self):
+        entity_list = [('user', 'firstname.lastname'), ('group', 'group-two')]
+        result = self.querytool._resolve_entities(entity_list)
+        assert len(result) == 2
+        assert isinstance(result[0], entities.FreeIPAUser)
+        assert result[0].name == 'firstname.lastname'
+        assert isinstance(result[1], entities.FreeIPAUserGroup)
+        assert result[1].name == 'group-two'
+
+    def test_resolve_entities_not_found(self):
+        entity_list = [('user', 'firstname.lastname'), ('group', 'not-exist')]
+        with pytest.raises(tool.ManagerError) as exc:
+            self.querytool._resolve_entities(entity_list)
+        assert exc.value[0] == 'group not-exist not found in config'
+
+    @log_capture()
+    def test_build_graph(self, log):
+        entity = self.querytool.entities['user']['firstname.lastname']
+        assert {repr(i) for i in self.querytool.build_graph(entity)} == {
+            'group group-one-users', 'group group-two',
+            'group group-three-users'}
+        assert dict((repr(k), set(map(repr, v)))
+                    for k, v in self.querytool.graph.iteritems()) == {
+            'group group-one-users': {'group group-two',
+                                      'group group-three-users'},
+            'group group-three-users': set(),
+            'group group-two': {'group group-three-users'},
+            'user firstname.lastname': {'group group-one-users',
+                                        'group group-two',
+                                        'group group-three-users'}}
+        assert dict((repr(k), map(repr, v))
+                    for k, v in self.querytool.ancestors.iteritems()) == {
+            'group group-one-users': ['user firstname.lastname'],
+            'group group-three-users': ['group group-two'],
+            'group group-two': ['group group-one-users']}
+        log.check(('QueryTool', 'DEBUG',
+                   'Calculating membership graph for firstname.lastname'),
+                  ('QueryTool', 'DEBUG',
+                   'Calculating membership graph for group-one-users'),
+                  ('QueryTool', 'DEBUG',
+                   'Calculating membership graph for group-two'),
+                  ('QueryTool', 'DEBUG',
+                   'Calculating membership graph for group-three-users'),
+                  ('QueryTool', 'DEBUG',
+                   'Found 0 entities for group-three-users'),
+                  ('QueryTool', 'DEBUG',
+                   'Found 1 entities for group-two'),
+                  ('QueryTool', 'DEBUG',
+                   'Found 2 entities for group-one-users'),
+                  ('QueryTool', 'DEBUG',
+                   'Found 3 entities for firstname.lastname'))
+
+    @log_capture(level=logging.INFO)
+    def test_check_membership(self, log):
+        member = self.querytool.entities['user']['firstname.lastname2']
+        entity = self.querytool.entities['group']['group-three-users']
+        paths = self.querytool.check_membership(member, entity)
+        assert len(paths) == 2
+        assert [repr(i) for i in paths[0]] == [
+            'user firstname.lastname2', 'group group-three-users']
+        assert [repr(i) for i in paths[1]] == [
+            'user firstname.lastname2', 'group group-four-users',
+            'group group-three-users']
+        log.check(
+            ('QueryTool', 'INFO',
+             ('firstname.lastname2 IS a member of group-three-users; '
+              'possible paths: [user firstname.lastname2 -> group '
+              'group-three-users; user firstname.lastname2 -> group '
+              'group-four-users -> group group-three-users]')))
+
+    def test_query_membership(self):
+        members = [('user', 'firstname.lastname2'),
+                   ('group', 'group-one-users')]
+        entity_list = [('group', 'group-one-users'),
+                       ('group', 'group-two'),
+                       ('group', 'group-three-users')]
+        self.querytool.check_membership = mock.Mock()
+        self.querytool._query_membership(members, entity_list)
+        assert [tuple(repr(i) for i in j.args) for j
+                in self.querytool.check_membership.call_args_list] == [
+            ('user firstname.lastname2', 'group group-one-users'),
+            ('user firstname.lastname2', 'group group-two'),
+            ('user firstname.lastname2', 'group group-three-users'),
+            ('group group-one-users', 'group group-one-users'),
+            ('group group-one-users', 'group group-two'),
+            ('group group-one-users', 'group group-three-users')]
+
+    @log_capture()
+    def test_construct_path(self):
+        members = [('user', 'firstname.lastname'),
+                   ('group', 'group-one-users')]
+        entity_list = [('group', 'group-one-users'),
+                       ('group', 'group-two'),
+                       ('group', 'group-three-users')]
+        self.querytool._query_membership(members, entity_list)
+        entity = self.querytool.entities['group']['group-two']
+        member = self.querytool.entities['user']['firstname.lastname']
+        paths = self.querytool._construct_path(entity, member)
+        assert len(paths) == 1
+        assert map(repr, paths[0]) == [
+            'user firstname.lastname', 'group group-one-users',
+            'group group-two']
+
+    @log_capture()
+    def test_construct_path_non_member(self):
+        members = [('user', 'firstname.lastname2'),
+                   ('group', 'group-one-users')]
+        entity_list = [('group', 'group-one-users'),
+                       ('group', 'group-two'),
+                       ('group', 'group-three-users')]
+        self.querytool._query_membership(members, entity_list)
+        entity = self.querytool.entities['group']['group-two']
+        member = self.querytool.entities['user']['firstname.lastname2']
+        assert self.querytool._construct_path(entity, member) == []
+
+
+class TestQueryToolTopLevel(object):
+    def test_entity_type(self):
+        assert tool._entity_type(
+            'sometype:somename') == ('sometype', 'somename')
+
+    def test_entity_type_error_too_few_values(self):
+        with pytest.raises(ValueError) as exc:
+            tool._entity_type('sometype,somename')
+        assert exc.value[0] == 'need more than 1 value to unpack'
+
+    def test_entity_type_error_too_many_values(self):
+        with pytest.raises(ValueError) as exc:
+            tool._entity_type('sometype:somename:something')
+        assert exc.value[0] == 'too many values to unpack'
+
+    def test_parse_args(self):
+        assert tool._parse_args([
+            'member', 'config', '-m', 'group:group1', 'user:user1',
+            '-e', 'group:group2', '-v', '-s', 'settings.yam'
+        ]) == argparse.Namespace(
+            action='member', config='config', loglevel=logging.INFO,
+            members=[('group', 'group1'), ('user', 'user1')],
+            pull_types=['user'], settings='settings.yam',
+            entities=[('group', 'group2')])
+
+    @mock.patch('%s.QueryTool' % modulename)
+    @mock.patch('%s._parse_args' % modulename)
+    def test_main(self, mock_parse_args, mock_querytool):
+        mock_parse_args.return_value = argparse.Namespace(
+            action='member', config='config', loglevel=20,
+            members=[('group', 'group1'), ('user', 'user1')],
+            pull_types=['user'], settings='settings.yam',
+            entities=[('group', 'group2')])
+        tool.main()
+        mock_querytool.assert_called_with('config', 'settings.yam', 20)
+        mock_querytool.return_value.load.assert_called_with()
+        mock_querytool.return_value.run.assert_called_with(
+            'member', [('group', 'group1'), ('user', 'user1')],
+            [('group', 'group2')])


### PR DESCRIPTION
Add the QueryTool component that'll enable various operations
over the entity config, such as checking membership of entity
in another entity, or checking if a required security label's
present in an entity as required by another entities' config.

For now, nested membership check is implemented only; labels'
checks are going to be implemented soon in a separate commit.