### PR TITLE
Make QueryTool an importable library

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ For example, to find if a group called `group1` is a member of the group `group2
 ipamanager-query member config-repo -m group:group1 -e group:group2
 ```
 
+The QueryTool functionality can also be imported to use from other Python code:
+```python
+from ipamanager.tools.query_tool import load_query_tool
+
+querytool = load_query_tool('config_repo', 'settings.yaml')
+querytool.check_user_membership('user.name', 'group-name')  # True/False
+for group in querytool.list_groups('user.name'):  # returns iterator
+    print group
+```
+
 ### Dry run
 The *dry run* mode can be choosen with `-d` or `--dry-run` flag.
 

--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-manager
 Version:        1.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
 License:        BSD License 2.0
@@ -46,6 +46,8 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-query
 
 %changelog
+* Tue May 28 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.7-2
+- Make ipamanager.tools.QueryTool easier to import
 * Tue May 28 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.7-1
 - Add a query tool into ipamanager.tools
 * Thu May 23 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.6-2

--- a/ipamanager/tools/query_tool.py
+++ b/ipamanager/tools/query_tool.py
@@ -170,6 +170,51 @@ class QueryTool(FreeIPAManagerToolCore):
         self.lg.debug('Found %d paths %s -> %s', len(paths), member, entity)
         return paths
 
+    def check_user_membership(self, user, group):
+        """
+        Check if `user` is a member of a `group`.
+        This function serves as a wrapper for easy usage from other scripts.
+        :param str user: name of the user to check
+        :param str group: name of the group to check
+        :returns: True if `user` is a member of `group`, False otherwise
+        :rtype: bool
+        """
+        user_entity = find_entity(self.entities, 'user', user)
+        if not user_entity:
+            raise ManagerError('User %s does not exist in config' % user)
+        group_entity = find_entity(self.entities, 'group', group)
+        if not group_entity:
+            raise ManagerError('Group %s does not exist in config' % group)
+        return bool(self.check_membership(user_entity, group_entity))
+
+    def list_groups(self, user):
+        """
+        Find all groups that `user` is a member of.
+        This function serves as a wrapper for easy import into other scripts.
+        :param str user: name of the user to check
+        :returns: generator of group names that `user` is a member of
+        :rtype: generator
+        """
+        user_entity = find_entity(self.entities, 'user', user)
+        if not user_entity:
+            raise ManagerError('User %s does not exist in config' % user)
+        groups = self.build_graph(user_entity)
+        return (i.name for i in groups)
+
+
+def load_query_tool(config, settings=None):
+    """
+    Initialize and return a QueryTool instance.
+    This function serves as a wrapper for easy import into other scripts.
+    :param str config: path to the config repository folder
+    :param str settings: path to the settings file
+    :returns: QueryTool instance that was initialized
+    :rtype: QueryTool
+    """
+    querytool = QueryTool(config, settings)
+    querytool.load()
+    return querytool
+
 
 def _parse_args(args=None):
     common = _args_common()


### PR DESCRIPTION
Add methods that enable easy imports
of the QueryTool functionality; this
will make it possible to query repos
with freeipa-manager entities config
as part of many other tools/scripts.