### PR TITLE
Add security label processing support

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-manager
-Version:        1.7
-Release:        2%{?dist}
+Version:        1.8
+Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
 License:        BSD License 2.0
@@ -46,6 +46,8 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-query
 
 %changelog
+* Wed May 29 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-1
+- Add label processing to ipamanager.tools.QueryTool
 * Tue May 28 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.7-2
 - Make ipamanager.tools.QueryTool easier to import
 * Tue May 28 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.7-1

--- a/ipamanager/tools/query_tool.py
+++ b/ipamanager/tools/query_tool.py
@@ -56,14 +56,15 @@ class QueryTool(FreeIPAManagerToolCore):
         self.checker.check()
         self.lg.info('Pre-query config load & checks finished')
 
-    def run(self, action, *args):
+    def run(self, args):
         """
         Run a query action based on arguments.
-        :param str action: action to perform (membership/security check)
-        :param [obj] args: arguments to pass to the action method
+        :param argparse.Namespace args: parsed args
         """
-        if action == 'member':
-            self._query_membership(*args)
+        if args.action == 'member':
+            self._query_membership(args.members, args.entities)
+        elif args.action == 'labels':
+            self._query_labels(args)
 
     def _resolve_entities(self, entity_list):
         """
@@ -201,6 +202,133 @@ class QueryTool(FreeIPAManagerToolCore):
         groups = self.build_graph(user_entity)
         return (i.name for i in groups)
 
+    def _query_labels(self, args):
+        """
+        Run a labels query based on `args.subaction`.
+        """
+        subactions = {
+            'check': lambda a: self.check_label_necessary(a.label, a.group),
+            'missing': lambda a: self.list_user_missing_labels(a.user),
+            'necessary': lambda a: self.list_necessary_labels(a.group),
+            'user': lambda a: self.check_user_necessary_labels(a.user, a.group)
+        }
+        subactions[args.subaction](args)
+
+    def _get_labels(self, entity):
+        """
+        Auxiliary function to get the metaparams/labels value of an entity.
+        Implemented purely for convenience of not having to write
+        this more complicated expression over and over again.
+        """
+        return entity.metaparams.get('labels', [])
+
+    def _list_necessary_labels(self, entity, include_self=False):
+        """
+        Find labels that an entity needs to have based on its membership.
+        This function is usually wrapped by one of the "public" methods
+        defined below, rather than called directly.
+        :param FreeIPAEntity entity: entity whose labels to list
+        :param bool include_self: whether to include the entity's own labels
+            (by default only nested entities' labels included)
+        :returns: list of labels defined for nested groups (and entity itself)
+        :rtype: [str]
+        """
+        labels = []
+        for group in self.build_graph(entity):
+            labels.extend(self._get_labels(group))
+        if include_self:
+            labels.extend(self._get_labels(entity))
+        return labels
+
+    def check_label_necessary(self, label, group):
+        """
+        Check if `label` is necessary for membership in `group`.
+        :param str label: label value
+        :param str group: name of the group to start the check from
+        :returns: True if `label` is needed, False otherwise
+        :rtype: bool
+        :raises ManagerError: if `group` is not defined in config
+        """
+        group_entity = find_entity(self.entities, 'group', group)
+        if not group_entity:
+            raise ManagerError('Group %s does not exist in config' % group)
+        labels = self._list_necessary_labels(group_entity, include_self=True)
+        result = label in labels
+        if result:
+            self.lg.info('Label %s IS necessary for group %s', label, group)
+        else:
+            self.lg.info("Label %s ISN'T necessary for group %s", label, group)
+        return result
+
+    def list_user_missing_labels(self, user):
+        """
+        List labels that a user is missing and is expected to have
+        based on their group membership.
+        :param str user: name of user whose labels to check
+        :returns: set of labels that `user` is missing
+        :rtype: {str}
+        :raises ManagerError: if `user` is not defined in config
+        """
+        user_entity = find_entity(self.entities, 'user', user)
+        if not user_entity:
+            raise ManagerError('User %s does not exist in config' % user)
+        necessary = set(self.list_necessary_labels(user_entity))
+        current = set(self._get_labels(user_entity))
+        missing = necessary.difference(current)
+        if missing:
+            self.lg.info('User %s misses labels: {%s}',
+                         user, ', '.join(missing))
+        else:
+            self.lg.info('User %s misses NO labels', user)
+        return missing
+
+    def list_necessary_labels(self, group):
+        """
+        Find labels that an entity needs to have based on its membership.
+        Serves as wrapper around the related private method
+        (plus entity resolution based on group name).
+        :param str group: name of group whose labels to list
+        :returns: list of labels defined for nested groups (and entity itself)
+        :rtype: [str]
+        :raises ManagerError: if `group` is not defined in config
+        """
+        group_entity = find_entity(self.entities, 'group', group)
+        if not group_entity:
+            raise ManagerError('Group %s does not exist in config' % group)
+        labels = self._list_necessary_labels(group_entity, include_self=True)
+        if labels:
+            self.lg.info('Group %s requires labels: [%s]',
+                         group, ', '.join(labels))
+        else:
+            self.lg.info('Group %s requires NO labels', group)
+        return labels
+
+    def check_user_necessary_labels(self, user, group):
+        """
+        Check if `user` has all the necessary labels for membership in `group`.
+        :param str name: name of the user to check
+        :param str group: name of the group to check
+        :returns: True if `user ` has all required labels, False otherwise
+        :rtype: bool
+        :raises ManagerError: if `user` or `group` is not defined in config
+        """
+        user_entity = find_entity(self.entities, 'user', user)
+        if not user_entity:
+            raise ManagerError('User %s does not exist in config' % user)
+        group_entity = find_entity(self.entities, 'group', group)
+        if not group_entity:
+            raise ManagerError('Group %s does not exist in config' % group)
+        user_labels = self._get_labels(user_entity)
+        required = self._list_necessary_labels(group_entity, include_self=True)
+        result = all(label in user_labels for label in required)
+        if result:
+            self.lg.info('User %s DOES have all required labels for group %s',
+                         user, group)
+        else:
+            self.lg.info('User %s DOES NOT have required labels for group %s',
+                         user, group)
+        return result
+
 
 def load_query_tool(config, settings=None):
     """
@@ -230,6 +358,28 @@ def _parse_args(args=None):
         required=True, help='entities whose members to check (type:name)')
     member.set_defaults(action='member')
 
+    labels = actions.add_parser('labels')
+    labels.set_defaults(action='labels')
+    labels_actions = labels.add_subparsers(help='labels query action')
+
+    labels_check = labels_actions.add_parser('check', parents=[common])
+    labels_check.set_defaults(subaction='check')
+    labels_check.add_argument('label', help='label value')
+    labels_check.add_argument('group', help='group name')
+
+    labels_missing = labels_actions.add_parser('missing', parents=[common])
+    labels_missing.set_defaults(subaction='missing')
+    labels_missing.add_argument('user', help='user name')
+
+    labels_necessary = labels_actions.add_parser('necessary', parents=[common])
+    labels_necessary.set_defaults(subaction='necessary')
+    labels_necessary.add_argument('group', help='group name')
+
+    labels_user = labels_actions.add_parser('user', parents=[common])
+    labels_user.set_defaults(subaction='user')
+    labels_user.add_argument('user', help='user name')
+    labels_user.add_argument('group', help='group name')
+
     args = parser.parse_args(args)
     args.loglevel = _type_verbosity(args.loglevel)
     return args
@@ -251,7 +401,7 @@ def main():
     args = _parse_args()
     querytool = QueryTool(args.config, args.settings, args.loglevel)
     querytool.load()
-    querytool.run(args.action, args.members, args.entities)
+    querytool.run(args)
 
 
 if __name__ == '__main__':

--- a/tests/freeipa-manager-config/correct/groups/group_one.yaml
+++ b/tests/freeipa-manager-config/correct/groups/group_one.yaml
@@ -4,3 +4,5 @@ group-one-users:
   memberOf:
     group:
       - group-two
+  metaparams:
+    labels: [approval, security]

--- a/tests/freeipa-manager-config/correct/groups/group_three.yaml
+++ b/tests/freeipa-manager-config/correct/groups/group_three.yaml
@@ -1,3 +1,5 @@
 ---
 group-three-users:
   description: Sample group three.
+  metaparams:
+    labels: [review]


### PR DESCRIPTION
Extend the QueryTool component to add
support of security label processing.
This enables one to define labels (in
the metaparams key) for groups, which
can then be assigned to users allowed
to be members of such groups. The API
of the tool is also extended, so that
the newly added methods are usable by
other scripts importing this library.