### PR TITLE
Cap change ratio values to one hundred percent

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-manager
 Version:        1.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
 License:        BSD License 2.0
@@ -46,6 +46,8 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager-query
 
 %changelog
+* Wed May 29 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-1
+- Fix change threshold calculation (cap values to 100 %)
 * Wed May 29 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-1
 - Add label processing to ipamanager.tools.QueryTool
 * Tue May 28 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.7-2

--- a/ipamanager/ipa_connector.py
+++ b/ipamanager/ipa_connector.py
@@ -232,10 +232,12 @@ class IpaUploader(IpaConnector):
                     'There were %d errors executing update' % len(self.errs))
 
     def _check_threshold(self):
-        if not self.ipa_entity_count:  # avoid divison by zero on empty IPA
-            ratio = 100
-        else:
-            ratio = 100 * float(len(self.commands))/self.ipa_entity_count
+        try:
+            abs_ratio = float(len(self.commands)) / self.ipa_entity_count
+        except ZeroDivisionError:
+            abs_ratio = 1
+        # cap change ratio to 100 % to avoid threshold issues
+        ratio = min(abs_ratio * 100, 100)
         self.lg.debug('%d commands, %d remote entities (%.2f %%)',
                       len(self.commands), self.ipa_entity_count, ratio)
         if ratio > self.threshold:

--- a/tests/test_ipa_connector.py
+++ b/tests/test_ipa_connector.py
@@ -551,6 +551,18 @@ class TestIpaUploader(TestIpaConnectorBase):
              '11 commands, 120 remote entities (9.17 %)'),
             ('IpaUploader', 'DEBUG', 'Threshold check passed'))
 
+    def test_check_threshold_over_100(self):
+        self._create_uploader(threshold=100)
+        self.uploader.commands = [
+            tool.Command('cmd%d' % i, {}, '', '') for i in range(1, 100)]
+        self.uploader.ipa_entity_count = 10
+        with LogCapture('IpaUploader', level=logging.DEBUG) as log:
+            self.uploader._check_threshold()
+        log.check(
+            ('IpaUploader', 'DEBUG',
+             '99 commands, 10 remote entities (100.00 %)'),
+            ('IpaUploader', 'DEBUG', 'Threshold check passed'))
+
     def test_check_threshold_empty_ipa(self):
         self._create_uploader(threshold=10)
         self.uploader.commands = [


### PR DESCRIPTION
Currently, adding a large count of entities to
a server that already has some entities is not
easily possible since the change ratio can get
determined to be over 100, while the threshold
argument only support values of 1-100. Fix the
situation by capping the possible change ratio
values to a maximum of 100 % in each scenario.