### PR TITLE
Enable Bash autocompletion of commandline usage

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,6 +1,6 @@
 Name:           freeipa-manager
 Version:        1.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
 License:        BSD License 2.0
@@ -10,12 +10,13 @@ Source0:        %{name}.tar.gz
 Requires:       python
 Requires:       gdc-python-common
 Requires:       PyYAML >= 3.10
+Requires:       python-argcomplete
 Requires:       python-requests >= 2.6.0
 Requires:       python-sh >= 1.11
 Requires:       python-voluptuous >= 0.8.5
 Requires:       python2-yamllint >= 1.8.1
 Requires:       /usr/sbin/send_nsca
-BuildRequires:  python-setuptools python-psutil pytest
+BuildRequires:  pytest python-argcomplete python-psutil python-setuptools
 Conflicts:      gdc-ipa-utils < 6
 
 %description
@@ -37,6 +38,10 @@ mkdir -p $RPM_BUILD_ROOT
 export PACKAGE_VERSION=%{version}.%{release}
 %{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
 
+# install autocompletion script
+mkdir -p $RPM_BUILD_ROOT/etc/bash_completion.d
+register-python-argcomplete ipamanager > $RPM_BUILD_ROOT/etc/bash_completion.d/ipamanager
+
 %files
 %defattr(-,root,root,-)
 %{python_sitelib}/freeipa_manager*
@@ -44,9 +49,12 @@ export PACKAGE_VERSION=%{version}.%{release}
 %{_bindir}/ipamanager
 %{_bindir}/ipamanager-pull-request
 %{_bindir}/ipamanager-query
+/etc/bash_completion.d/ipamanager
 
 %changelog
-* Wed May 29 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-1
+* Tue Sep 10 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-3
+- Add Bash command autocompletion
+* Fri Sep 06 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-2
 - Fix change threshold calculation (cap values to 100 %)
 * Wed May 29 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-1
 - Add label processing to ipamanager.tools.QueryTool

--- a/ipamanager/freeipa_manager.py
+++ b/ipamanager/freeipa_manager.py
@@ -27,8 +27,9 @@ class FreeIPAManager(FreeIPAManagerCore):
     Main runnable class responsible for coordinating module functionality.
     """
     def __init__(self):
-        super(FreeIPAManager, self).__init__()
+        # parse_args is called by argcomplete; must be as fast as possible
         self.args = utils.parse_args()
+        super(FreeIPAManager, self).__init__()
         utils.init_logging(self.args.loglevel)
         self._load_settings()
 

--- a/ipamanager/utils.py
+++ b/ipamanager/utils.py
@@ -8,6 +8,7 @@ FreeIPA Manager - utility module
 Various utility functions for better code readability & organization.
 """
 
+import argcomplete
 import argparse
 import logging
 import logging.handlers
@@ -125,7 +126,8 @@ def _args_common():
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument('config', help='Config repository path')
     common.add_argument('-p', '--pull-types', nargs='+', default=['user'],
-                        help='Types of entities to pull')
+                        help='Types of entities to pull',
+                        choices=[cls.entity_name for cls in ENTITY_CLASSES])
     common.add_argument('-s', '--settings', help='Settings file')
     common.add_argument('-v', '--verbose', action='count', default=0,
                         dest='loglevel', help='Verbose mode (-vv for debug)')
@@ -173,6 +175,7 @@ def parse_args():
         help='Load all entities (including ignored ones)')
     roundtrip.set_defaults(action='roundtrip')
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
     # type & action cannot be combined in arg constructor, so parse -v here
     args.loglevel = _type_verbosity(args.loglevel)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argcomplete
 pyyaml
 requests
 sh

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands = flake8 --ignore=E402 tests
 
 [testenv:freeipa-manager-py27]
 deps =
+    argcomplete
     mock
     pytest
     pytest-cov


### PR DESCRIPTION
Make use of the upstream argcomplete library to
simplify manual command-line usage of the tool.

Reorganize the main class initialization a bit,
so that parse_args method comes among the first
actions executed by the tool, and therefore, so
that the Tab completion is as fast as possible.