### PR TITLE
Lock argcomplete's version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argcomplete
+argcomplete <= 1.10
 pyyaml
 requests
 sh


### PR DESCRIPTION
The newer version has some dependency
issues; let's lock the version to fix
tests while we figure out a solution.