### PR TITLE
Lock sh dependency version below 1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete <= 1.10
 pyyaml
 requests
-sh
+sh < 1.14
 voluptuous
 yamllint


### PR DESCRIPTION
The recently released version causes issues with
argcomplete dependency installation. A newer RPM
version is not needed; tests clone repo directly
and RPM doesn't use pip for dependency installs.