### PR TITLE
Lock yamllint dependency below the 1.25.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyyaml
 requests
 sh < 1.14
 voluptuous
-yamllint
+yamllint < 1.25


### PR DESCRIPTION
Our code's not ready for today's version.