### PR TITLE
Introduce new nsca_hostname parameter

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.9
+Version:        1.10
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/alerting/nsca.py
+++ b/ipamanager/alerting/nsca.py
@@ -37,6 +37,8 @@ class NscaAlertingPlugin(AlertingPlugin):
             raise ConfigError(
                 'Parameter service must be defined for %s' % self.name)
 
+        self.nsca_hostname = config.get('nsca_hostname', socket.getfqdn())
+
     def _status_code(self):
         """
         Get the status code to dispatch to NSCA (0, 1 or 2) based on max_level.
@@ -50,7 +52,7 @@ class NscaAlertingPlugin(AlertingPlugin):
         return 0
 
     def _run_dispatch(self, code, message):
-        data = '%s;%s;%s;%s' % (socket.getfqdn(), self.service, code, message)
+        data = '%s;%s;%s;%s' % (self.nsca_hostname, self.service, code, message)
         self.lg.debug('Dispatching NSCA data: %s', data)
         sp = Popen((self.command, '-d', ';'),
                    stdin=PIPE, stdout=PIPE, stderr=PIPE)

--- a/tests/alerting/test_nsca.py
+++ b/tests/alerting/test_nsca.py
@@ -23,7 +23,8 @@ class TestAlerting(object):
                 'err': 'Some errors:'
             },
             'command': '/dev/null/send_nsca',
-            'service': 'ipamanager-push'
+            'service': 'ipamanager-push',
+            'nsca_hostname': 'freeipa-node'
         }
         if not method.func_name.startswith('test_init'):
             self.plugin = tool.NscaAlertingPlugin(self.config)
@@ -83,7 +84,6 @@ class TestAlerting(object):
     @mock.patch('ipamanager.alerting.nsca.Popen')
     @mock.patch('ipamanager.alerting.nsca.socket')
     def test_run_dispatch(self, mock_sock, mock_popen, log):
-        mock_sock.getfqdn.return_value = 'freeipa-node'
         ret = self.plugin._run_dispatch(7, 'some msg')
         mock_popen.assert_called_with(
             ('/dev/null/send_nsca', '-d', ';'), stdin=-1, stdout=-1, stderr=-1)


### PR DESCRIPTION
It can be used for override of default socket.getfqdn() hostname.
Useful when instance hostname in icinga is different than actual
FQDN of instance where freeipa-manager is running