### PR TITLE
Add support for Okta to FreeIPA user sync

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.10
+Version:        1.11
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
@@ -52,6 +52,8 @@ register-python-argcomplete ipamanager > $RPM_BUILD_ROOT/etc/bash_completion.d/i
 /etc/bash_completion.d/ipamanager
 
 %changelog
+* Mon Mar 10 2021 Kristian Lesko <kristian.lesko@gooddata.com> - 1.11-1
+- Support syncing users from Okta instead of Git
 * Mon May 25 2020 Kristian Lesko <kristian.lesko@gooddata.com> - 1.9-1
 - Support filter parameters in permission entity
 * Tue Sep 10 2019 Kristian Lesko <kristian.lesko@gooddata.com> - 1.8-3

--- a/ipamanager/config_loader.py
+++ b/ipamanager/config_loader.py
@@ -87,8 +87,8 @@ class ConfigLoader(FreeIPAManagerCore):
         for name, attrs in data.iteritems():
             self.lg.debug('Creating entity %s', name)
             if self.ignore and check_ignored(entity_class, name, self.ignored):
-                self.lg.info('Not creating ignored %s %s from %s',
-                             entity_class.entity_name, name, fname)
+                self.lg.debug('Not creating ignored %s %s from %s',
+                              entity_class.entity_name, name, fname)
                 continue
             entity = entity_class(name, attrs, path)
             if name in self.entities[entity_class.entity_name]:

--- a/ipamanager/errors.py
+++ b/ipamanager/errors.py
@@ -21,3 +21,7 @@ class ConfigError(ManagerError):
 
 class IntegrityError(ConfigError):
     """Error raised in case of integrity checking failure."""
+
+
+class OktaError(ManagerError):
+    """Error raised in case of issues with Okta communication."""

--- a/ipamanager/okta_loader.py
+++ b/ipamanager/okta_loader.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2021, GoodData Corporation. All rights reserved.
+"""
+FreeIPA Manager - Okta user loading module
+
+Module for loading user configuration from Okta account.
+"""
+
+import re
+import requests
+
+from core import FreeIPAManagerCore
+from errors import OktaError
+from entities import FreeIPAOktaUser
+from utils import check_ignored
+
+
+class OktaLoader(FreeIPAManagerCore):
+    """
+    Responsible for loading users from Okta.
+    :attr dict users: Structure of users loaded from Okta
+    """
+    def __init__(self, settings, groups):
+        """
+        :param dict settings: parsed contents of the settings file
+        :param list(str) groups: current groups defined for FreeIPA
+        """
+        super(OktaLoader, self).__init__()
+        self.ignored = {'user': settings['okta'].get('ignore', [])}
+
+        self.ipa_groups = set(groups)
+
+        self.settings = settings
+        okta_auth = self.settings['okta']['auth']
+
+        self.okta_org = okta_auth['org']
+        self.okta_token = self._load_okta_token(okta_auth['token_path'])
+        self.okta_url = 'https://%s.okta.com/api/v1' % self.okta_org
+
+        self._setup_okta_session()
+
+    def _load_okta_token(self, path):
+        with open(path) as tokenfile:
+            return tokenfile.read().strip()
+
+    def _setup_okta_session(self):
+        self.session = requests.Session()
+        self.session.headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': 'SSWS %s' % self.okta_token
+        }
+
+    def load(self):
+        """
+        Parse Okta users and attributes.
+        """
+        self.lg.info('Loading users from Okta')
+        users = dict()
+        uid_regex = self.settings['okta']['user_id_regex']
+        for user in self._get_okta_api_pages('%s/users' % self.okta_url):
+            # parse UID from Okta
+            uid_raw = user['profile']['login']
+            if uid_regex:
+                try:
+                    uid = re.match(uid_regex, uid_raw).group(1)
+                except AttributeError:
+                    self.lg.warning(
+                        'User %s does not match UID regex "%s", skipping',
+                        uid_raw, uid_regex)
+                    continue
+            else:
+                uid = uid_raw
+
+            # check if ignored
+            if check_ignored(FreeIPAOktaUser, uid, self.ignored):
+                self.lg.info('Not creating ignored Okta user %s', uid)
+                continue
+
+            user_config = dict()
+
+            # handle Okta user status
+            status = user['status']
+            if status in ('STAGED', 'DEPROVISIONED'):
+                self.lg.debug('User %s is %s in Okta, not creating',
+                              uid, status)
+                # shouldn't be in FreeIPA at all
+                continue
+            elif status == 'SUSPENDED':
+                self.lg.debug('User %s is %s in Okta, setting as disabled',
+                              uid, status)
+                # should be disabled
+                user_config['disabled'] = True
+            elif status in ('PROVISIONED', 'ACTIVE',
+                            'PASSWORD_EXPIRED', 'LOCKED_OUT', 'RECOVERY'):
+                self.lg.debug('User %s is %s in Okta, creating as active user',
+                              uid, status)
+                user_config['disabled'] = False
+
+            for attr in self.settings['okta']['attributes']:
+                if attr in user['profile']:
+                    user_config[attr] = user['profile'][attr]
+            groups = set(self._user_groups(user)).intersection(self.ipa_groups)
+            if groups:
+                user_config['memberOf'] = {'group': list(groups)}
+
+            users[uid] = FreeIPAOktaUser(uid, user_config)
+        self.lg.debug('Users loaded from Okta: %s', users.keys())
+        self.lg.info('%d users loaded from Okta', len(users))
+        return users
+
+    def load_groups(self):
+        okta_groups = [group['profile']['name'] for group in
+                       self._get_okta_api_pages('%s/groups' % self.okta_url)]
+        # only take groups that are both in Okta & IPA
+        filtered_groups = list(set(okta_groups).intersection(self.ipa_groups))
+        self.lg.debug('Groups loaded from Okta: %s', filtered_groups)
+        self.lg.info('%d groups loaded from Okta', len(filtered_groups))
+        return filtered_groups
+
+    def _get_okta_api_pages(self, url):
+        self.lg.debug('Reading Okta users from %s', url)
+        resp = self.session.get(url)
+        if not resp.ok:
+            raise OktaError('Error reading users from Okta: %s', resp.text)
+        users = resp.json()
+        # handle pagination:
+        if resp.links.get('next'):
+            users.extend(self._get_okta_api_pages(resp.links['next']['url']))
+        return users
+
+    def _user_groups(self, user):
+        self.lg.debug('Reading user %s (%s) Okta groups',
+                      user['profile']['login'], user['id'])
+        resp = self.session.get('%s/users/%s/groups'
+                                % (self.okta_url, user['id']))
+        if not resp.ok:
+            raise OktaError('Error getting user %s groups: %s',
+                            user['profile']['login'], resp.text)
+        return (gr['profile']['name'] for gr in resp.json())

--- a/ipamanager/schemas.py
+++ b/ipamanager/schemas.py
@@ -33,7 +33,17 @@ schema_settings = {
             'hbacsvc', 'hbacsvcgroup'): [str]
     },
     'nesting-limit': int,
-    'user-group-pattern': str
+    'user-group-pattern': str,
+    'okta': {
+        'enabled': bool,
+        'ignore': [str],
+        Required('attributes'): [str],
+        Required('auth'): {
+            Required('org'): str,
+            Required('token_path'): str
+        },
+        'user_id_regex': str
+    }
 }
 
 

--- a/tests/okta/groups.json
+++ b/tests/okta/groups.json
@@ -1,0 +1,26 @@
+[
+    {
+        "profile": {
+            "description": null,
+            "name": "oktagroup1"
+        }
+    },
+    {
+        "profile": {
+            "description": null,
+            "name": "oktagroup2"
+        }
+    },
+    {
+        "profile": {
+            "description": null,
+            "name": "commongroup1"
+        }
+    },
+    {
+        "profile": {
+            "description": null,
+            "name": "commongroup2"
+        }
+    }
+]

--- a/tests/okta/user_groups.json
+++ b/tests/okta/user_groups.json
@@ -1,0 +1,16 @@
+[
+    {
+        "created": "2020-10-19T05:23:24.000Z",
+        "id": "00gbpj1cvRiSMYvYz5d5",
+        "lastMembershipUpdated": "2021-02-26T15:03:20.000Z",
+        "lastUpdated": "2020-10-19T05:23:24.000Z",
+        "objectClass": [
+            "okta:user_group"
+        ],
+        "profile": {
+            "description": "All users in your organization",
+            "name": "Everyone"
+        },
+        "type": "BUILT_IN"
+    }
+]

--- a/tests/okta/users.json
+++ b/tests/okta/users.json
@@ -1,0 +1,148 @@
+[
+    {
+        "_links": {
+            "self": {
+                "href": "https://gooddata.okta.com/api/v1/users/00u99999999999999999"
+            }
+        },
+        "activated": "2020-11-20T16:18:44.000Z",
+        "created": "2020-11-20T15:18:43.000Z",
+        "credentials": {
+            "password": {},
+            "provider": {
+                "name": "OKTA",
+                "type": "OKTA"
+            },
+            "recovery_question": {
+                "question": "test?"
+            }
+        },
+        "id": "00u99999999999999999",
+        "lastLogin": "2021-01-17T16:29:51.000Z",
+        "lastUpdated": "2021-01-17T16:28:46.000Z",
+        "passwordChanged": "2021-01-17T16:28:46.000Z",
+        "profile": {
+            "email": "some.user@devgdc.com",
+            "firstName": "Some",
+            "lastName": "User",
+            "login": "some.user@devgdc.com",
+            "mobilePhone": null,
+            "secondEmail": null,
+            "manager": ""
+        },
+        "status": "ACTIVE",
+        "statusChanged": "2020-11-19T16:43:04.000Z",
+        "type": {
+            "id": "aaaaaaaaaaaaaaaaaaaa"
+        }
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://gooddata.okta.com/api/v1/users/00u99999999999999991"
+            }
+        },
+        "activated": "2020-11-20T16:18:44.000Z",
+        "created": "2020-11-20T15:18:43.000Z",
+        "credentials": {
+            "password": {},
+            "provider": {
+                "name": "OKTA",
+                "type": "OKTA"
+            },
+            "recovery_question": {
+                "question": "test2?"
+            }
+        },
+        "id": "00u99999999999999991",
+        "lastLogin": "2021-01-17T16:29:51.000Z",
+        "lastUpdated": "2021-01-17T16:28:46.000Z",
+        "passwordChanged": "2021-01-17T16:28:46.000Z",
+        "profile": {
+            "email": "other.user@devgdc.com",
+            "firstName": "Other",
+            "lastName": "User",
+            "login": "other.user@devgdc.com",
+            "mobilePhone": null,
+            "secondEmail": null,
+            "manager": "manager.one"
+        },
+        "status": "SUSPENDED",
+        "statusChanged": "2020-11-19T16:43:04.000Z",
+        "type": {
+            "id": "aaaaaaaaaaaaaaaaaaaa"
+        }
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://gooddata.okta.com/api/v1/users/00u99999999999999998"
+            }
+        },
+        "activated": "2020-11-20T16:18:44.000Z",
+        "created": "2020-11-20T15:18:43.000Z",
+        "credentials": {
+            "password": {},
+            "provider": {
+                "name": "OKTA",
+                "type": "OKTA"
+            },
+            "recovery_question": {
+                "question": "test3?"
+            }
+        },
+        "id": "00u99999999999999998",
+        "lastLogin": "2021-01-17T16:29:51.000Z",
+        "lastUpdated": "2021-01-17T16:28:46.000Z",
+        "passwordChanged": "2021-01-17T16:28:46.000Z",
+        "profile": {
+            "email": "different.user@otherdomain.com",
+            "firstName": "Some",
+            "lastName": "User",
+            "login": "different.user@otherdomain.com",
+            "mobilePhone": null,
+            "secondEmail": null
+        },
+        "status": "ACTIVE",
+        "statusChanged": "2020-11-19T16:43:04.000Z",
+        "type": {
+            "id": "aaaaaaaaaaaaaaaaaaaa"
+        }
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://gooddata.okta.com/api/v1/users/00u99999999999999997"
+            }
+        },
+        "activated": "2020-11-20T16:18:44.000Z",
+        "created": "2020-11-20T15:18:43.000Z",
+        "credentials": {
+            "password": {},
+            "provider": {
+                "name": "OKTA",
+                "type": "OKTA"
+            },
+            "recovery_question": {
+                "question": "test4?"
+            }
+        },
+        "id": "00u99999999999999997",
+        "lastLogin": "2021-01-17T16:29:51.000Z",
+        "lastUpdated": "2021-01-17T16:28:46.000Z",
+        "passwordChanged": "2021-01-17T16:28:46.000Z",
+        "profile": {
+            "email": "terminated.user@devgdc.com",
+            "firstName": "Some",
+            "lastName": "User",
+            "login": "terminated.user@devgdc.com",
+            "mobilePhone": null,
+            "secondEmail": null
+        },
+        "status": "DEPROVISIONED",
+        "statusChanged": "2020-11-19T16:43:04.000Z",
+        "type": {
+            "id": "aaaaaaaaaaaaaaaaaaaa"
+        }
+    }
+]

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -174,7 +174,7 @@ class TestConfigLoader(object):
             'More than one entity parsed from users/test_user.yaml (2)'
         )
 
-    @log_capture('ConfigLoader', level=logging.INFO)
+    @log_capture('ConfigLoader', level=logging.DEBUG)
     def test_parse_ignored(self, captured_log):
         data = {'test.user': {'firstName': 'first', 'lastName': 'last'}}
         self.loader.entities['user'] = []
@@ -183,9 +183,11 @@ class TestConfigLoader(object):
             data, entities.FreeIPAUser,
             '%s/users/test_user.yaml' % CONFIG_CORRECT)
         assert self.loader.entities['user'] == []
-        captured_log.check(('ConfigLoader', 'INFO',
-                            ('Not creating ignored user test.user '
-                             'from users/test_user.yaml')))
+        captured_log.check(
+            ('ConfigLoader', 'DEBUG', 'Creating entity test.user'),
+            ('ConfigLoader', 'DEBUG',
+             'Not creating ignored user test.user '
+             'from users/test_user.yaml'))
 
     @log_capture('ConfigLoader', level=logging.INFO)
     def test_load(self, captured_log):
@@ -239,13 +241,7 @@ class TestConfigLoader(object):
             ('ConfigLoader', 'INFO', 'Parsed 3 roles'),
             ('ConfigLoader', 'INFO', 'Parsed 3 services'),
             ('ConfigLoader', 'INFO', 'Parsed 3 sudorules'),
-            ('ConfigLoader', 'INFO',
-             ('Not creating ignored user firstname.lastname '
-              'from users/firstname_lastname.yaml')),
             ('ConfigLoader', 'INFO', 'Parsed 2 users'),
-            ('ConfigLoader', 'INFO',
-             ('Not creating ignored group group-one-users '
-              'from groups/group_one.yaml')),
             ('ConfigLoader', 'INFO', 'Parsed 3 groups'))
 
     @log_capture('ConfigLoader', level=logging.INFO)

--- a/tests/test_freeipa_manager.py
+++ b/tests/test_freeipa_manager.py
@@ -169,7 +169,8 @@ class TestFreeIPAManagerRun(TestFreeIPAManagerBase):
                 manager = self._init_tool(['push', 'config_repo', '-ft', '10'])
                 manager.entities = dict()
                 manager.run()
-        mock_conn.assert_called_with(manager.settings, {}, 10, True, False)
+        mock_conn.assert_called_with(
+            manager.settings, {}, 10, True, False, False, [])
 
     def test_run_push_enable_deletion(self):
         with mock.patch('ipamanager.ipa_connector.IpaUploader') as mock_conn:
@@ -177,7 +178,8 @@ class TestFreeIPAManagerRun(TestFreeIPAManagerBase):
                 manager = self._init_tool(['push', 'repo_path', '-fdt', '10'])
                 manager.entities = dict()
                 manager.run()
-        mock_conn.assert_called_with(manager.settings, {}, 10, True, True)
+        mock_conn.assert_called_with(
+            manager.settings, {}, 10, True, True, False, [])
 
     def test_run_push_dry_run(self):
         with mock.patch('ipamanager.ipa_connector.IpaUploader') as mock_conn:
@@ -185,7 +187,8 @@ class TestFreeIPAManagerRun(TestFreeIPAManagerBase):
                 manager = self._init_tool(['push', 'config_repo'])
                 manager.entities = dict()
                 manager.run()
-        mock_conn.assert_called_with(manager.settings, {}, 10, False, False)
+        mock_conn.assert_called_with(
+            manager.settings, {}, 10, False, False, False, [])
 
     def test_run_push_dry_run_enable_deletion(self):
         with mock.patch('ipamanager.ipa_connector.IpaUploader') as mock_conn:
@@ -193,7 +196,8 @@ class TestFreeIPAManagerRun(TestFreeIPAManagerBase):
                 manager = self._init_tool(['push', 'config_repo', '-d'])
                 manager.entities = dict()
                 manager.run()
-        mock_conn.assert_called_with(manager.settings, {}, 10, False, True)
+        mock_conn.assert_called_with(
+            manager.settings, {}, 10, False, True, False, [])
 
     def test_run_pull(self):
         with mock.patch('ipamanager.ipa_connector.IpaDownloader') as mock_conn:

--- a/tests/test_okta_loader.py
+++ b/tests/test_okta_loader.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright © 2017-2019, GoodData Corporation. All rights reserved.
+
+import json
+import mock
+import os.path
+import requests_mock
+from testfixtures import LogCapture
+
+from _utils import _import
+tool = _import('ipamanager', 'okta_loader')
+entities = _import('ipamanager', 'entities')
+utils = _import('ipamanager', 'utils')
+modulename = 'ipamanager.config_loader'
+testpath = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestConfigLoader(object):
+    def setup_method(self, method):
+        settings = {'okta': {
+            'auth': {'org': 'testoktaorg', 'token_path': '/test/okta.token'},
+            'ignore': ['admin', 'user1'],
+            'attributes': ['email', 'firstName', 'lastName',
+                           'initials', 'githubLogin'],
+            'user_id_regex': '(.+)@devgdc.com'
+        }}
+        ipa_groups = ['ipagroup1', 'ipagroup2', 'commongroup1', 'commongroup2']
+        with mock.patch('__builtin__.open',
+                        mock.mock_open(read_data='okta-token-1\n')):
+            self.loader = tool.OktaLoader(settings, ipa_groups)
+
+    def test_init(self):
+        assert self.loader.ipa_groups == {
+            'commongroup1', 'commongroup2', 'ipagroup1', 'ipagroup2'}
+        assert self.loader.ignored == {'user': ['admin', 'user1']}
+        assert self.loader.okta_org == 'testoktaorg'
+        assert self.loader.okta_token == 'okta-token-1'
+        assert self.loader.session.headers == {
+            'Accept': 'application/json',
+            'Authorization': 'SSWS okta-token-1',
+            'Content-Type': 'application/json'
+        }
+
+    def _mock_groups(self, user):
+        user_groups = {
+            '00u99999999999999999': [
+                'oktagroup1', 'oktagroup2', 'commongroup1'],
+            '00u99999999999999991': ['oktagroup3', 'commongroup2']
+        }
+        return user_groups.get(user['id'], [])
+
+    def test_load(self):
+        self.loader._get_okta_api_pages = mock.Mock()
+        with open(os.path.join(testpath, 'okta/users.json')) as resp_users_fh:
+            resp_users = json.load(resp_users_fh)
+            self.loader._get_okta_api_pages.return_value = resp_users
+        self.loader._user_groups = self._mock_groups
+
+        with LogCapture() as log:
+            users = self.loader.load()
+
+        assert users.keys() == [u'some.user', u'other.user']
+
+        assert users[u'some.user'].data_ipa == {
+            'givenname': (u'Some',), 'mail': (u'some.user@devgdc.com',),
+            'memberof': {'group': ['commongroup1']}, 'sn': (u'User',),
+            'nsaccountlock': False}
+        assert users[u'some.user'].data_repo == {
+            'email': u'some.user@devgdc.com', 'firstName': u'Some',
+            'lastName': u'User', 'memberOf': {'group': ['commongroup1']},
+            'disabled': False}
+
+        assert users[u'other.user'].data_ipa == {
+            'givenname': (u'Other',), 'mail': (u'other.user@devgdc.com',),
+            'memberof': {'group': ['commongroup2']}, 'sn': (u'User',),
+            'nsaccountlock': True}
+        assert users[u'other.user'].data_repo == {
+            'email': u'other.user@devgdc.com', 'firstName': u'Other',
+            'lastName': u'User', 'memberOf': {'group': ['commongroup2']},
+            'disabled': True}
+
+        log.check(
+            ('OktaLoader', 'INFO', 'Loading users from Okta'),
+            ('OktaLoader', 'DEBUG',
+             u'User some.user is ACTIVE in Okta, creating as active user'),
+            ('OktaLoader', 'DEBUG',
+             u'User other.user is SUSPENDED in Okta, setting as disabled'),
+            ('OktaLoader', 'WARNING',
+             u'User different.user@otherdomain.com does not '
+             u'match UID regex "(.+)@devgdc.com", skipping'),
+            ('OktaLoader', 'DEBUG',
+             u'User terminated.user is DEPROVISIONED in Okta, not creating'),
+            ('OktaLoader', 'DEBUG',
+             "Users loaded from Okta: [u'some.user', u'other.user']"),
+            ('OktaLoader', 'INFO', '2 users loaded from Okta'))
+
+    def test_load_groups(self):
+        self.loader._get_okta_api_pages = mock.Mock()
+        with open(os.path.join(testpath, 'okta/groups.json')) as resp_groups_fh:
+            resp_groups = json.load(resp_groups_fh)
+            self.loader._get_okta_api_pages.return_value = resp_groups
+
+        groups = self.loader.load_groups()
+        assert set(groups) == {'commongroup1', 'commongroup2'}
+
+    def test_get_okta_api_pages(self):
+        okta_mock = requests_mock.mock()
+        okta_url = 'https://testoktaorg.okta.com/v1/tests'
+        okta_url2 = 'https://testoktaorg.okta.com/v1/tests/page2'
+        resp1 = [{'part': 'one'}]
+        resp2 = [{'part': 'two'}]
+        okta_mock.get(okta_url, json=resp1, headers={
+            'link': '<%s>; rel="next"' % okta_url2})
+        okta_mock.get(okta_url2, json=resp2)
+        with okta_mock:
+            assert self.loader._get_okta_api_pages(okta_url) == [
+                {u'part': u'one'}, {u'part': u'two'}]
+
+    def test_user_groups(self):
+        okta_mock = requests_mock.mock()
+        okta_url = 'https://testoktaorg.okta.com/api/v1/users/userid123/groups'
+
+        with open(os.path.join(testpath, 'okta/groups.json')) as ug_fh:
+            okta_mock.get(okta_url, text=ug_fh.read())
+
+        with okta_mock:
+            user = {'id': 'userid123', 'profile': {'login': 'user1'}}
+            assert list(self.loader._user_groups(user)) == [
+                u'oktagroup1', u'oktagroup2', u'commongroup1', u'commongroup2']


### PR DESCRIPTION
Allow using Okta instead of Git config as source for user config.
See individual commit messages for details on implementation.