### PR TITLE
Remove mandatory yamllint dependency

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.11
+Version:        1.12
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
@@ -14,7 +14,6 @@ Requires:       python-argcomplete
 Requires:       python-requests >= 2.6.0
 Requires:       python-sh >= 1.11
 Requires:       python-voluptuous >= 0.8.5
-Requires:       python2-yamllint >= 1.8.1
 Requires:       /usr/sbin/send_nsca
 BuildRequires:  pytest python-argcomplete python-psutil python-setuptools
 Conflicts:      gdc-ipa-utils < 6

--- a/ipamanager/config_loader.py
+++ b/ipamanager/config_loader.py
@@ -15,7 +15,7 @@ import yaml
 
 from core import FreeIPAManagerCore
 from errors import ConfigError
-from utils import ENTITY_CLASSES, check_ignored, run_yamllint_check
+from utils import ENTITY_CLASSES, check_ignored
 
 
 class ConfigLoader(FreeIPAManagerCore):
@@ -55,8 +55,6 @@ class ConfigLoader(FreeIPAManagerCore):
                 try:
                     with open(path, 'r') as confsource:
                         contents = confsource.read()
-                    run_yamllint_check(contents)
-                    self.lg.debug('%s yamllint check passed', fname)
                     data = yaml.safe_load(contents)
                     self._parse(data, entity_class, path)
                 except (IOError, ConfigError, yaml.YAMLError) as e:

--- a/ipamanager/utils.py
+++ b/ipamanager/utils.py
@@ -18,11 +18,8 @@ import socket
 import sys
 import voluptuous
 import yaml
-from yamllint.config import YamlLintConfig
-from yamllint.linter import run as yamllint_check
 
 import entities
-from errors import ConfigError
 from schemas import schema_settings
 
 
@@ -189,20 +186,6 @@ def parse_args():
     return args
 
 
-def run_yamllint_check(data):
-    """
-    Run a yamllint check on parsed file contents
-    to verify that the file syntax is correct.
-    :param str data: contents of the configuration file to check
-    :param yamllint.config.YamlLintConfig: yamllint config to use
-    :raises ConfigError: in case of yamllint errors
-    """
-    rules = {'extends': 'default', 'rules': {'line-length': 'disable'}}
-    lint_errs = list(yamllint_check(data, YamlLintConfig(yaml.dump(rules))))
-    if lint_errs:
-        raise ConfigError('yamllint errors: %s' % lint_errs)
-
-
 def _merge_include(target, source):
     for key, value in source.iteritems():
         if isinstance(value, dict) and key in target:
@@ -223,7 +206,6 @@ def load_settings(path):
     result = {}
     with open(path) as src:
         raw = src.read()
-        run_yamllint_check(raw)
         settings = yaml.safe_load(raw)
     # run validation of parsed YAML against schema
     voluptuous.Schema(schema_settings)(settings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pyyaml
 requests
 sh < 1.14
 voluptuous
-yamllint < 1.25

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -103,28 +103,6 @@ class TestConfigLoader(object):
             'No privilege files found',
             'No permission files found'])
 
-    @log_capture('ConfigLoader', level=logging.DEBUG)
-    def test_run_yamllint_check_ok(self, captured_log):
-        data = '---\ntest-group:\n  description: A test group.\n'
-        tool.run_yamllint_check(data)
-        captured_log.check()
-
-    @log_capture('ConfigLoader', level=logging.DEBUG)
-    def test_run_yamllint_check_long_line(self, captured_log):
-        data = '---\ntest-group:\n  description: %s\n' % ('x' * 80)
-        tool.run_yamllint_check(data)
-        captured_log.check()
-
-    def test_run_yamllint_check_error(self):
-        data = 'test-group:\n  description: A test group.\n  description: test'
-        with pytest.raises(tool.ConfigError) as exc:
-            tool.run_yamllint_check(data)
-        assert exc.value[0] == (
-            'yamllint errors: [1:1: missing document start "---" '
-            '(document-start), 3:3: duplication of key "description" '
-            'in mapping (key-duplicates), 3:20: no new line character '
-            'at the end of file (new-line-at-end-of-file)]')
-
     def test_parse(self):
         self.loader.entities = {'user': {}}
         data = {'test.user': {'firstName': 'first', 'lastName': 'last'}}

--- a/tests/test_okta_loader.py
+++ b/tests/test_okta_loader.py
@@ -7,7 +7,7 @@ import json
 import mock
 import os.path
 import requests_mock
-from testfixtures import LogCapture
+from testfixtures import LogCapture, StringComparison
 
 from _utils import _import
 tool = _import('ipamanager', 'okta_loader')
@@ -61,7 +61,7 @@ class TestConfigLoader(object):
         with LogCapture() as log:
             users = self.loader.load()
 
-        assert users.keys() == [u'some.user', u'other.user']
+        assert set(users.keys()) == {u'some.user', u'other.user'}
 
         assert users[u'some.user'].data_ipa == {
             'givenname': (u'Some',), 'mail': (u'some.user@devgdc.com',),
@@ -92,8 +92,8 @@ class TestConfigLoader(object):
              u'match UID regex "(.+)@devgdc.com", skipping'),
             ('OktaLoader', 'DEBUG',
              u'User terminated.user is DEPROVISIONED in Okta, not creating'),
-            ('OktaLoader', 'DEBUG',
-             "Users loaded from Okta: [u'some.user', u'other.user']"),
+            ('OktaLoader', 'DEBUG', StringComparison(
+                "Users loaded from Okta: .+")),
             ('OktaLoader', 'INFO', '2 users loaded from Okta'))
 
     def test_load_groups(self):

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,4 @@ deps =
     sh
     testfixtures
     voluptuous
-    yamllint
 commands = py.test --cov ipamanager --junitxml=ipamanager/tests.xml -vv tests


### PR DESCRIPTION
Downloading the yamllint package via
PyPI often fails; remove dependency.
This isn't critical for tool itself.