### PR TITLE
Improve Okta loader functionality

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.13
+Version:        1.14
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/entities.py
+++ b/ipamanager/entities.py
@@ -380,7 +380,7 @@ class FreeIPAOktaUser(FreeIPAUser):
         'lastName': 'sn',
         'githubLogin': 'carLicense',
         'department': 'ou',
-        'sshkey': 'ipaSshPubKey',
+        'sshKeys': 'ipaSshPubKey',
         'disabled': 'nsAccountLock'
     }
 

--- a/ipamanager/ipa_connector.py
+++ b/ipamanager/ipa_connector.py
@@ -179,13 +179,7 @@ class IpaUploader(IpaConnector):
         target_types = [cls.entity_name for cls in ENTITY_CLASSES
                         if entity.entity_name in cls.allowed_members]
         for target_type in target_types:
-            if (entity.entity_name == 'user' and target_type == 'group'
-                    and self.okta_users):
-                targets = [gr for gr in self.okta_groups
-                           if gr in self.ipa_entities[target_type]]
-            else:
-                targets = self.ipa_entities[target_type].keys()
-            for target in targets:
+            for target in self.ipa_entities[target_type]:
                 members = self.ipa_entities[target_type][target].data_ipa.get(
                     'member_%s' % entity.entity_name, [])
                 if entity.name in members:

--- a/ipamanager/okta_loader.py
+++ b/ipamanager/okta_loader.py
@@ -83,7 +83,7 @@ class OktaLoader(FreeIPAManagerCore):
 
             # handle Okta user status
             status = user['status']
-            if status in ('STAGED', 'DEPROVISIONED'):
+            if status == 'DEPROVISIONED':
                 self.lg.debug('User %s is %s in Okta, not creating',
                               uid, status)
                 # shouldn't be in FreeIPA at all
@@ -93,11 +93,14 @@ class OktaLoader(FreeIPAManagerCore):
                               uid, status)
                 # should be disabled
                 user_config['disabled'] = True
-            elif status in ('PROVISIONED', 'ACTIVE',
+            elif status in ('PROVISIONED', 'ACTIVE', 'STAGED',
                             'PASSWORD_EXPIRED', 'LOCKED_OUT', 'RECOVERY'):
-                self.lg.debug('User %s is %s in Okta, creating as active user',
+                self.lg.debug('User %s is %s in Okta, setting as active user',
                               uid, status)
                 user_config['disabled'] = False
+            else:
+                raise OktaError('User %s in unexpected state: %s'
+                                % (uid, status))
 
             for attr in self.settings['okta']['attributes']:
                 if attr in user['profile']:

--- a/tests/okta/users.json
+++ b/tests/okta/users.json
@@ -28,7 +28,8 @@
             "login": "some.user@devgdc.com",
             "mobilePhone": null,
             "secondEmail": null,
-            "manager": ""
+            "employeeNumber": "123",
+            "manager": null
         },
         "status": "ACTIVE",
         "statusChanged": "2020-11-19T16:43:04.000Z",
@@ -65,7 +66,8 @@
             "login": "other.user@devgdc.com",
             "mobilePhone": null,
             "secondEmail": null,
-            "manager": "manager.one"
+            "managerId": "123",
+            "manager": "Some User"
         },
         "status": "SUSPENDED",
         "statusChanged": "2020-11-19T16:43:04.000Z",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -516,7 +516,7 @@ class TestFreeIPAOktaUser(object):
             'githubLogin': 'some-name-123',
             'manager': '',
             'memberOf': {'group': ['okta-group-one']},
-            'sshkey': 'ssh-key-test'
+            'sshKeys': ['ssh-key-test']
         }
         user = tool.FreeIPAOktaUser('test.user', data)
         assert user.name == 'test.user'

--- a/tests/test_okta_loader.py
+++ b/tests/test_okta_loader.py
@@ -75,16 +75,18 @@ class TestConfigLoader(object):
         assert users[u'other.user'].data_ipa == {
             'givenname': (u'Other',), 'mail': (u'other.user@devgdc.com',),
             'memberof': {'group': ['commongroup2']}, 'sn': (u'User',),
-            'nsaccountlock': True}
+            'nsaccountlock': True, 'manager': (u'some.user',)}
         assert users[u'other.user'].data_repo == {
             'email': u'other.user@devgdc.com', 'firstName': u'Other',
             'lastName': u'User', 'memberOf': {'group': ['commongroup2']},
-            'disabled': True}
+            'disabled': True, 'manager': u'some.user'}
 
         log.check(
             ('OktaLoader', 'INFO', 'Loading users from Okta'),
             ('OktaLoader', 'DEBUG',
              u'User some.user is ACTIVE in Okta, setting as active user'),
+            ('OktaLoader', 'WARNING',
+             u'User some.user has no manager defined'),
             ('OktaLoader', 'DEBUG',
              u'User other.user is SUSPENDED in Okta, setting as disabled'),
             ('OktaLoader', 'WARNING',

--- a/tests/test_okta_loader.py
+++ b/tests/test_okta_loader.py
@@ -84,7 +84,7 @@ class TestConfigLoader(object):
         log.check(
             ('OktaLoader', 'INFO', 'Loading users from Okta'),
             ('OktaLoader', 'DEBUG',
-             u'User some.user is ACTIVE in Okta, creating as active user'),
+             u'User some.user is ACTIVE in Okta, setting as active user'),
             ('OktaLoader', 'DEBUG',
              u'User other.user is SUSPENDED in Okta, setting as disabled'),
             ('OktaLoader', 'WARNING',


### PR DESCRIPTION
### Handle pagination for Okta user groups
An Okta user may be in more groups than
returned on a single API response page.

### Delete Okta-synced users from extra groups
Ignoring groups that exist in IPA, but not
in Okta, could case unintended accesses to
be granted or not revoked. Instead, let us
track all group membership (and create the
needed groups on Okta side as well), so we
are sure only expected groups're assigned.

### Create staged users as active too
It makes sense for our use cases.

### Parse Okta users' manager by employee numbers
The manager field in Okta is a full name that
is hard to map; however, a combination of the
managedId attribute and employeeNumber lookup
does the trick, so add it to the Okta loader.

### Fix SSH key Okta attribute name