### PR TITLE
Revert "Delete Okta-synced users from extra groups"

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.14
+Version:        1.15
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/ipa_connector.py
+++ b/ipamanager/ipa_connector.py
@@ -179,7 +179,13 @@ class IpaUploader(IpaConnector):
         target_types = [cls.entity_name for cls in ENTITY_CLASSES
                         if entity.entity_name in cls.allowed_members]
         for target_type in target_types:
-            for target in self.ipa_entities[target_type]:
+            if (entity.entity_name == 'user' and target_type == 'group'
+                    and self.okta_users):
+                targets = [gr for gr in self.okta_groups
+                           if gr in self.ipa_entities[target_type]]
+            else:
+                targets = self.ipa_entities[target_type].keys()
+            for target in targets:
                 members = self.ipa_entities[target_type][target].data_ipa.get(
                     'member_%s' % entity.entity_name, [])
                 if entity.name in members:


### PR DESCRIPTION
This reverts commit 64849cb465e33afeb03be47dc2a72185fd1acdc3.

It is not practical to port all the groups to Okta.
We'll rather use the pull mode to verify extra access.