### PR TITLE
Don't sync user emails from Okta

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.15
+Version:        1.16
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/entities.py
+++ b/ipamanager/entities.py
@@ -370,12 +370,12 @@ class FreeIPAUser(FreeIPAEntity):
 
 class FreeIPAOktaUser(FreeIPAUser):
     """Representation of a FreeIPA user fetched from Okta."""
-    managed_attributes_push = FreeIPAUser.managed_attributes_push + [
-        'ipaSshPubKey']
+    managed_attributes_push = [
+        attr for attr in FreeIPAUser.managed_attributes_push
+        if attr != 'mail'] + ['ipaSshPubKey']
     # we don't support pulling from IPA to Okta
     managed_attributes_pull = []
     key_mapping = {
-        'email': 'mail',
         'firstName': 'givenName',
         'lastName': 'sn',
         'githubLogin': 'carLicense',

--- a/tests/okta/users.json
+++ b/tests/okta/users.json
@@ -22,7 +22,6 @@
         "lastUpdated": "2021-01-17T16:28:46.000Z",
         "passwordChanged": "2021-01-17T16:28:46.000Z",
         "profile": {
-            "email": "some.user@devgdc.com",
             "firstName": "Some",
             "lastName": "User",
             "login": "some.user@devgdc.com",
@@ -60,7 +59,6 @@
         "lastUpdated": "2021-01-17T16:28:46.000Z",
         "passwordChanged": "2021-01-17T16:28:46.000Z",
         "profile": {
-            "email": "other.user@devgdc.com",
             "firstName": "Other",
             "lastName": "User",
             "login": "other.user@devgdc.com",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -510,7 +510,6 @@ class TestFreeIPAOktaUser(object):
     def test_create_user_correct(self):
         data = {
             'disabled': True,
-            'email': 'some.name@devgdc.com',
             'firstName': 'Some',
             'lastName': 'Name',
             'githubLogin': 'some-name-123',
@@ -525,7 +524,6 @@ class TestFreeIPAOktaUser(object):
             'carlicense': (u'some-name-123',),
             'givenname': (u'Some',),
             'ipasshpubkey': (u'ssh-key-test',),
-            'mail': (u'some.name@devgdc.com',),
             'memberof': {'group': ['okta-group-one']},
             'sn': (u'Name',), 'nsaccountlock': True
         }

--- a/tests/test_okta_loader.py
+++ b/tests/test_okta_loader.py
@@ -17,7 +17,7 @@ modulename = 'ipamanager.config_loader'
 testpath = os.path.dirname(os.path.abspath(__file__))
 
 
-class TestConfigLoader(object):
+class TestOktaLoader(object):
     def setup_method(self, method):
         settings = {'okta': {
             'auth': {'org': 'testoktaorg', 'token_path': '/test/okta.token'},
@@ -64,21 +64,21 @@ class TestConfigLoader(object):
         assert set(users.keys()) == {u'some.user', u'other.user'}
 
         assert users[u'some.user'].data_ipa == {
-            'givenname': (u'Some',), 'mail': (u'some.user@devgdc.com',),
-            'memberof': {'group': ['commongroup1']}, 'sn': (u'User',),
+            'givenname': (u'Some',), 'sn': (u'User',),
+            'memberof': {'group': ['commongroup1']},
             'nsaccountlock': False}
         assert users[u'some.user'].data_repo == {
-            'email': u'some.user@devgdc.com', 'firstName': u'Some',
-            'lastName': u'User', 'memberOf': {'group': ['commongroup1']},
+            'firstName': u'Some', 'lastName': u'User',
+            'memberOf': {'group': ['commongroup1']},
             'disabled': False}
 
         assert users[u'other.user'].data_ipa == {
-            'givenname': (u'Other',), 'mail': (u'other.user@devgdc.com',),
-            'memberof': {'group': ['commongroup2']}, 'sn': (u'User',),
+            'givenname': (u'Other',), 'sn': (u'User',),
+            'memberof': {'group': ['commongroup2']},
             'nsaccountlock': True, 'manager': (u'some.user',)}
         assert users[u'other.user'].data_repo == {
-            'email': u'other.user@devgdc.com', 'firstName': u'Other',
-            'lastName': u'User', 'memberOf': {'group': ['commongroup2']},
+            'firstName': u'Other', 'lastName': u'User',
+            'memberOf': {'group': ['commongroup2']},
             'disabled': True, 'manager': u'some.user'}
 
         log.check(


### PR DESCRIPTION
This doesn't fit our use case as
we have multiple emails per user
and not enough fields in Okta to
store these custom email values.