### PR TITLE
Add group filter support in Okta loader

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.16
+Version:        1.17
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/schemas.py
+++ b/ipamanager/schemas.py
@@ -36,6 +36,7 @@ schema_settings = {
     'user-group-pattern': str,
     'okta': {
         'enabled': bool,
+        'user_group_filter': [str],
         'ignore': [str],
         Required('attributes'): [str],
         Required('auth'): {


### PR DESCRIPTION
In some IPA domains, we do not sync all
users, only members of specific groups.

Add support for this, by ignoring users
who aren't in such groups at sync time.