### PR TITLE
Allow ignoring manager from Okta

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.17
+Version:        1.18
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/okta_loader.py
+++ b/ipamanager/okta_loader.py
@@ -128,10 +128,10 @@ class OktaLoader(FreeIPAManagerCore):
                 self.lg.info('User %s has no group from filter, skipping', uid)
                 continue
 
-            # parse manager
-            manager = self._parse_manager(uid, user, uid_regex)
-            if manager:
-                user_config['manager'] = manager
+            if self.settings['okta'].get('parse_manager', True):
+                manager = self._parse_manager(uid, user, uid_regex)
+                if manager:
+                    user_config['manager'] = manager
 
             users[uid] = FreeIPAOktaUser(uid, user_config)
         self.lg.debug('Users loaded from Okta: %s', users.keys())

--- a/ipamanager/schemas.py
+++ b/ipamanager/schemas.py
@@ -37,6 +37,7 @@ schema_settings = {
     'okta': {
         'enabled': bool,
         'user_group_filter': [str],
+        'parse_manager': bool,
         'ignore': [str],
         Required('attributes'): [str],
         Required('auth'): {


### PR DESCRIPTION
This is a follow-up to the previous change from yesterday;
when we only sync certain users from Okta (based on group
membership), it is possible that a user's manager will not
be synced, and the integrity check will then fail.

Therefore, we need to add an option to ignore the manager
field when syncing users from Okta to FreeIPA.