### PR TITLE
Don't load users from Okta in check mode

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.18
+Version:        1.19
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 

--- a/ipamanager/freeipa_manager.py
+++ b/ipamanager/freeipa_manager.py
@@ -99,6 +99,12 @@ class FreeIPAManager(FreeIPAManagerCore):
         self.entities = self.config_loader.load()
 
         if self.okta_users:
+            if self.args.action == 'check':
+                self.lg.info('Okta user loading not supported in test')
+                self.entities['user'] = {}
+                self.okta_groups = []
+                return
+
             # only groups defined both in IPA & Okta are taken for Okta users
             ipa_groups = self.entities.get('group', []).keys()
             self.okta_loader = OktaLoader(self.settings, ipa_groups)


### PR DESCRIPTION
For increased security, avoid needing to
deliver live Okta token to testing infra.