### PR TITLE
TRIVIAL: Drop explicit dependency on /usr/sbin/send_nsca

### DIFF
--- a/freeipa-manager.spec
+++ b/freeipa-manager.spec
@@ -1,5 +1,5 @@
 Name:           freeipa-manager
-Version:        1.20
+Version:        1.21
 Release:        1%{?dist}
 Summary:        FreeIPA entity provisioning tool
 
@@ -15,7 +15,6 @@ Requires:       python-requests >= 2.6.0
 Requires:       python-sh >= 1.11
 Requires:       python-voluptuous >= 0.8.5
 Requires:       python2-yamllint >= 1.8.1
-Requires:       /usr/sbin/send_nsca
 BuildRequires:  pytest python-argcomplete python-psutil python-setuptools
 Conflicts:      gdc-ipa-utils < 6
 


### PR DESCRIPTION
The send_nsca is no longer in rpm but rather it is delivered by puppet,
so explicit dependency in rpm no longer makes sense