### PR TITLE
Lock certifi to Python 2-compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 argcomplete <= 1.10
 pyyaml < 6
+certifi < 2022
 requests
 sh < 1.14
 voluptuous>=0.7,<=0.12.2


### PR DESCRIPTION
The recently released version is Python 3-only.